### PR TITLE
Set initial phase to zero

### DIFF
--- a/sfmbase/PhaseDiscriminator.cpp
+++ b/sfmbase/PhaseDiscriminator.cpp
@@ -27,7 +27,8 @@
 PhaseDiscriminator::PhaseDiscriminator(double max_freq_dev)
     : m_normalize_factor(max_freq_dev * 2.0 * M_PI),
       // boundary = M_PI / m_normalize_factor;
-      m_boundary(1.0 / (max_freq_dev * 2.0)) {}
+      m_boundary(1.0 / (max_freq_dev * 2.0)),
+      m_save_value(0) {}
 
 // Process samples.
 void PhaseDiscriminator::process(const IQSampleVector &samples_in,


### PR DESCRIPTION
Running airspy-fmradion inside valgrind produces many errors about use of uninitialized memory:

```
==1508577== Conditional jump or move depends on uninitialised value(s)
==1508577==    at 0x4A073F5: volk_32f_s32f_32f_fm_detect_32f_u_avx (volk_32f_s32f_32f_fm_detect_32f.h:287)
==1508577==    by 0x4A073F5: volk_32f_s32f_32f_fm_detect_32f_u_avx (volk_32f_s32f_32f_fm_detect_32f.h:261)
==1508577==    by 0x13BB09: FmDecoder::process(std::vector<std::complex<float>, std::allocator<std::complex<float> > > const&, std::vector<double, std::allocator<double> >&) (FmDecode.cpp:282)
==1508577==    by 0x121635: main (main.cpp:980)
==1508577== 
==1508577== Conditional jump or move depends on uninitialised value(s)
==1508577==    at 0x4A07403: volk_32f_s32f_32f_fm_detect_32f_u_avx (volk_32f_s32f_32f_fm_detect_32f.h:289)
==1508577==    by 0x4A07403: volk_32f_s32f_32f_fm_detect_32f_u_avx (volk_32f_s32f_32f_fm_detect_32f.h:261)
==1508577==    by 0x13BB09: FmDecoder::process(std::vector<std::complex<float>, std::allocator<std::complex<float> > > const&, std::vector<double, std::allocator<double> >&) (FmDecode.cpp:282)
==1508577==    by 0x121635: main (main.cpp:980)
==1508577== 
==1508577== Conditional jump or move depends on uninitialised value(s)
==1508577==    at 0x13BBC5: sqrt (cmath:464)
==1508577==    by 0x13BBC5: samples_mean_rms (Utility.h:125)
==1508577==    by 0x13BBC5: FmDecoder::process(std::vector<std::complex<float>, std::allocator<std::complex<float> > > const&, std::vector<double, std::allocator<double> >&) (FmDecode.cpp:299)
==1508577==    by 0x121635: main (main.cpp:980)
==1508577== 

[...]
```

It appears they all occur because `m_save_value` is uninitialized. Passing this uninitialized value into `volk_32f_s32f_32f_fm_detect_32f` may corrupt the output samples.

Initializing `m_save_value` to zero fixes the errors.