### PR TITLE
Remove NaNs and process hanging

### DIFF
--- a/include/Utility.h
+++ b/include/Utility.h
@@ -300,6 +300,17 @@ inline double get_time() {
   return tv.tv_sec + (1.0e-6 * tv.tv_usec);
 }
 
+// Remove NaNs and infinities from a SampleVector
+// by substituting them to zeros.
+inline void remove_nans(IQSampleDecodedVector &samples) {
+  for (size_t i = 0; i < samples.size(); i++) {
+    double v = samples[i];
+    if (std::isnan(v) || !std::isfinite(v)) {
+      samples[i] = 0;
+    }
+  }
+}
+
 }; // namespace Utility
 
 #endif /* INCLUDE_UTILITY_H_ */

--- a/main.cpp
+++ b/main.cpp
@@ -1006,14 +1006,6 @@ int main(int argc, char **argv) {
     size_t audiosamples_size = audiosamples.size();
     bool audio_exists = audiosamples_size > 0;
 
-    // substitute nan in audiosamples to a very small value
-    for (size_t i = 0; i < audiosamples_size; i++) {
-      double v = audiosamples[i];
-      if (std::isnan(v) || !std::isfinite(v) || v == 0.0) {
-        v = 1e-9;
-      }
-    }
-
     // Measure audio level when audio exists
     if (audio_exists) {
       float audio_mean, audio_rms;

--- a/main.cpp
+++ b/main.cpp
@@ -915,7 +915,7 @@ int main(int argc, char **argv) {
     // If no IF data is sent,
     // go back and wait again
     if (iqsamples.empty()) {
-      // go back to the top of the for loop
+      // go to the end of the for loop
       continue;
     }
 
@@ -971,9 +971,20 @@ int main(int argc, char **argv) {
     double if_rms = 0.0;
 
     if (!if_exists) {
-      // go back to the top of the for loop
+      // go to the end of the for loop
       continue;
     }
+
+    if (modtype == ModType::FM) {
+      // the minus factor is to show the ppm correction
+      // to make and not the one which has already been made
+      ppm_average.feed((fm.get_tuning_offset() / tuner_freq) * -1.0e6);
+    } else if (modtype == ModType::NBFM) {
+      ppm_average.feed((nbfm.get_tuning_offset() / tuner_freq) * -1.0e6);
+    }
+
+    // Add 1e-9 to log10() to prevent generating NaN
+    float if_level_db = 20 * log10(if_level + 1e-9);
 
     // Valid data exists in if_samples from here
 
@@ -1006,31 +1017,27 @@ int main(int argc, char **argv) {
     size_t audiosamples_size = audiosamples.size();
     bool audio_exists = audiosamples_size > 0;
 
-    // Measure audio level when audio exists
-    if (audio_exists) {
-      float audio_mean, audio_rms;
-      IQSampleDecodedVector audiosamples_float;
-      audiosamples_float.resize(audiosamples_size);
-      volk_64f_convert_32f(audiosamples_float.data(), audiosamples.data(),
-                           audiosamples_size);
-      Utility::samples_mean_rms(audiosamples_float, audio_mean, audio_rms);
-      audio_level = 0.95 * audio_level + 0.05 * audio_rms;
-
-      // Set nominal audio volume (-6dB) when IF squelch is open,
-      // set to zero volume if the squelch is closed.
-      Utility::adjust_gain(audiosamples, if_rms >= squelch_level ? 0.5 : 0.0);
+    if (!audio_exists) {
+      // go to the end of the for loop
+      continue;
     }
 
-    if (modtype == ModType::FM) {
-      // the minus factor is to show the ppm correction
-      // to make and not the one which has already been made
-      ppm_average.feed((fm.get_tuning_offset() / tuner_freq) * -1.0e6);
-    } else if (modtype == ModType::NBFM) {
-      ppm_average.feed((nbfm.get_tuning_offset() / tuner_freq) * -1.0e6);
-    }
+    // Valid audio data exists in audiosamplesfrom here
 
-    // Add 1e-9 to log10() to prevent generating NaN
-    float if_level_db = 20 * log10(if_level + 1e-9);
+    // Measure audio level
+    float audio_mean, audio_rms;
+    IQSampleDecodedVector audiosamples_float;
+    audiosamples_float.resize(audiosamples_size);
+    volk_64f_convert_32f(audiosamples_float.data(), audiosamples.data(),
+                         audiosamples_size);
+    Utility::samples_mean_rms(audiosamples_float, audio_mean, audio_rms);
+    audio_level = 0.95 * audio_level + 0.05 * audio_rms;
+
+    // Set nominal audio volume (-6dB) when IF squelch is open,
+    // set to zero volume if the squelch is closed.
+    Utility::adjust_gain(audiosamples, if_rms >= squelch_level ? 0.5 : 0.0);
+    // Write samples to output.
+    output_buffer.push(std::move(audiosamples));
 
     // Show status messages for each block if not in quiet mode.
     bool stereo_change = false;
@@ -1151,12 +1158,6 @@ int main(int argc, char **argv) {
         }
         break;
       }
-    }
-
-    // Throw away unstable blocks during the startup.
-    if (audio_exists) {
-      // Write samples to output.
-      output_buffer.push(std::move(audiosamples));
     }
   }
 

--- a/main.cpp
+++ b/main.cpp
@@ -880,21 +880,6 @@ int main(int argc, char **argv) {
   // TODO: ~0.1sec / display (should be tuned)
   unsigned int stat_rate =
       lrint(5120 / (if_blocksize / total_decimation_ratio));
-  unsigned int discarding_blocks;
-  switch (modtype) {
-  case ModType::FM:
-  case ModType::NBFM:
-    discarding_blocks = stat_rate * 20;
-    break;
-  case ModType::AM:
-  case ModType::DSB:
-  case ModType::USB:
-  case ModType::LSB:
-  case ModType::CW:
-  case ModType::WSPR:
-    discarding_blocks = stat_rate * 10;
-    break;
-  }
 
   float if_level = 0;
 
@@ -981,7 +966,8 @@ int main(int argc, char **argv) {
     }
 
     // Downsample IF for the decoder.
-    bool if_exists = if_samples.size() > 0;
+    size_t if_samples_size = if_samples.size();
+    bool if_exists = if_samples_size > 0;
     double if_rms = 0.0;
 
     if (!if_exists) {
@@ -1020,6 +1006,14 @@ int main(int argc, char **argv) {
     size_t audiosamples_size = audiosamples.size();
     bool audio_exists = audiosamples_size > 0;
 
+    // substitute nan in audiosamples to a very small value
+    for (size_t i = 0; i < audiosamples_size; i++) {
+      double v = audiosamples[i];
+      if (std::isnan(v) || !std::isfinite(v) || v == 0.0) {
+        v = 1e-9;
+      }
+    }
+
     // Measure audio level when audio exists
     if (audio_exists) {
       float audio_mean, audio_rms;
@@ -1049,7 +1043,7 @@ int main(int argc, char **argv) {
     // Show status messages for each block if not in quiet mode.
     bool stereo_change = false;
     if (!quietmode) {
-      if (((block % stat_rate) == 0) && (block > discarding_blocks)) {
+      if ((block % stat_rate) == 0) {
         // Stereo detection display
         if (modtype == ModType::FM) {
           stereo_change = (fm.stereo_detected() != got_stereo);
@@ -1121,7 +1115,7 @@ int main(int argc, char **argv) {
 
 #ifdef COEFF_MONITOR
       if ((modtype == ModType::FM) && (multipathfilter_stages > 0) &&
-          ((block % (stat_rate * 10)) == 0) && (block > discarding_blocks)) {
+          (block % (stat_rate * 10)) == 0) {
         double mf_error = fm.get_multipath_error();
         const MfCoeffVector &mf_coeff = fm.get_multipath_coefficients();
         fprintf(stderr, "block,%" PRIu64 ",mf_error,%.9f,mf_coeff,", block,
@@ -1168,7 +1162,7 @@ int main(int argc, char **argv) {
     }
 
     // Throw away unstable blocks during the startup.
-    if ((block > discarding_blocks) && audio_exists) {
+    if (audio_exists) {
       // Write samples to output.
       output_buffer.push(std::move(audiosamples));
     }

--- a/sfmbase/FmDecode.cpp
+++ b/sfmbase/FmDecode.cpp
@@ -280,6 +280,9 @@ void FmDecoder::process(const IQSampleVector &samples_in, SampleVector &audio) {
     return;
   }
 
+  // Remove possible NaNs and irregular values
+  Utility::remove_nans(m_buf_decoded);
+
   // Convert decoded data to baseband data
   m_buf_baseband.resize(decoded_size);
   volk_32f_convert_64f(m_buf_baseband.data(), m_buf_decoded.data(),

--- a/sfmbase/MultipathFilter.cpp
+++ b/sfmbase/MultipathFilter.cpp
@@ -169,12 +169,6 @@ bool MultipathFilter::process(const IQSampleVector &samples_in,
   const unsigned int filter_interval = 0x03;
   for (unsigned int i = 0; i < n; i++) {
     IQSample output = single_process(samples_in[i]);
-    // Quick hack to prevent zero output
-    // so that it would not cause NaN
-    // in volk_32fc_s32f_atan2_32f() of PhaseDiscriminator
-    if ((output.real() == 0) && (output.imag() == 0)) {
-      return false;
-    }
     // Note well: -ffast-math DISABLES NaN processing (-menable-no-nans)
     // so DO NOT specify -ffast-math!
     // Check if output real/imag are finite

--- a/sfmbase/NbfmDecode.cpp
+++ b/sfmbase/NbfmDecode.cpp
@@ -65,6 +65,10 @@ void NbfmDecoder::process(const IQSampleVector &samples_in,
     audio.resize(0);
     return;
   }
+
+  // Remove possible NaNs and irregular values
+  Utility::remove_nans(m_buf_decoded);
+
   // Convert decoded data to baseband data
   m_buf_baseband.resize(decoded_size);
   volk_32f_convert_64f(m_buf_baseband.data(), m_buf_decoded.data(),


### PR DESCRIPTION
This pull request includes the fixes for the following bugs:

* Causing a hung process during the startup period before valid audio signals are coming out
* Causing displaying `-nan` in the output level meter in broadcast FM and NBFM
  - The NaN is presumably generated by `volk_32fc_s32f_atan2_32f()` in `PhaseDiscriminator::process()`
  - This bug also causes output disruption when the multipath filter is activated for broadcast FM

This pull request includes the following enhancements:

* Streamlining processing flow in the main for loop of `main()`
* Removing the initial waiting period for startup; the output is now activated from the block number 1
* Adding `Utility::remove_nans()`, a function to check and substitute NaNs and infinity values in IQSamplesDecodedVector