### PR TITLE
PhaseDiscriminator: handle special 0+0j case here

### DIFF
--- a/include/PhaseDiscriminator.h
+++ b/include/PhaseDiscriminator.h
@@ -38,8 +38,7 @@ public:
    * Output is a sequence of frequency estimates, scaled such that
    * output value +/- 1.0 represents the maximum frequency deviation.
    */
-  void process(const IQSampleVector &samples_in,
-               IQSampleDecodedVector &samples_out);
+  void process(IQSampleVector &samples_in, IQSampleDecodedVector &samples_out);
 
 private:
   const Sample m_normalize_factor;

--- a/main.cpp
+++ b/main.cpp
@@ -51,7 +51,7 @@
 // define this for enabling coefficient monitor functions
 // #undef COEFF_MONITOR
 
-#define AIRSPY_FMRADION_VERSION "20231216-0"
+#define AIRSPY_FMRADION_VERSION "20231217-no-nan"
 
 // Flag to set graceful termination
 // in process_signals()

--- a/sfmbase/FmDecode.cpp
+++ b/sfmbase/FmDecode.cpp
@@ -279,9 +279,6 @@ void FmDecoder::process(const IQSampleVector &samples_in, SampleVector &audio) {
     return;
   }
 
-  // Remove possible NaNs and irregular values
-  Utility::remove_nans(m_buf_decoded);
-
   // Convert decoded data to baseband data
   m_buf_baseband.resize(decoded_size);
   volk_32f_convert_64f(m_buf_baseband.data(), m_buf_decoded.data(),

--- a/sfmbase/NbfmDecode.cpp
+++ b/sfmbase/NbfmDecode.cpp
@@ -66,9 +66,6 @@ void NbfmDecoder::process(const IQSampleVector &samples_in,
     return;
   }
 
-  // Remove possible NaNs and irregular values
-  Utility::remove_nans(m_buf_decoded);
-
   // Convert decoded data to baseband data
   m_buf_baseband.resize(decoded_size);
   volk_32f_convert_64f(m_buf_baseband.data(), m_buf_decoded.data(),


### PR DESCRIPTION
This is a minimal modification to avoid inputting 0+0j to volk_32fc_s32f_atan2_32f().

Note: I'd rather want to remove this sort of hack altogether if [my fix for VOLK 3.1.0](https://github.com/gnuradio/volk/pull/731) is accepted in the next VOLK release. After that, a possible workaround should be setting the corresponding volk_config entry as: `volk_32fc_s32f_atan2_32f polynomial polynomial`
