### PR TITLE
CMakeLists.txt: add compile_commands.json support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,6 +8,9 @@ if(COMMAND cmake_policy)
   cmake_policy(SET CMP0003 NEW)
 endif(COMMAND cmake_policy)
 
+# Enable compile_commands.json as default
+set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
+
 # Use cmake-git-version-tracking
 include(FetchContent)
 FetchContent_Declare(cmake_git_version_tracking
@@ -15,6 +18,14 @@ FetchContent_Declare(cmake_git_version_tracking
   GIT_TAG 9b5fc5088b4089ff2adc20d607976b9923e3d737
 )
 FetchContent_MakeAvailable(cmake_git_version_tracking)
+# EXPORT_COMPILE_COMMANDS is supported for CMake version 3.20 or later only
+if (CMAKE_VERSION VERSION_LESS 3.20.0)
+    message(STATUS "No EXPORT_COMPILE_COMMANDS available")
+    message(STATUS "Use compdb for proper compile_commands.json handling")
+else()
+    set_target_properties(cmake_git_version_tracking
+      PROPERTIES EXPORT_COMPILE_COMMANDS OFF)
+endif()
 
 # Use pkg-config
 include(FindPkgConfig)


### PR DESCRIPTION
* Enable default compile_commands.json support
* *For CMake 3.20.0 and later only*: disable compile_commands.json for cmake-git-version-tracking code
  - To prevent unwanted cluttering of clangd
* If a complete support for compile_commands.json is needed, use [compdb](https://github.com/Sarcasm/compdb#generate-a-compilation-database-with-header-files)
  - `compdb -p build/ list > ./compile_commands.json`