### PR TITLE
Stop using PilotState::Detected

### DIFF
--- a/include/SoftFM.h
+++ b/include/SoftFM.h
@@ -53,6 +53,6 @@ enum class OutputMode {
   WAV_FLOAT32,
   PORTAUDIO
 };
-enum class PilotState { NotDetected, Detected, Stabilized };
+enum class PilotState { NotDetected, Detected };
 
 #endif

--- a/main.cpp
+++ b/main.cpp
@@ -842,7 +842,6 @@ int main(int argc, char **argv) {
   float if_level = 0;
 
   PilotState pilot_status = PilotState::NotDetected;
-  constexpr float pilot_level_threshold = 0.02;
 
   ///////////////////////////////////////
   // NOTE: main processing loop from here

--- a/main.cpp
+++ b/main.cpp
@@ -987,15 +987,12 @@ int main(int argc, char **argv) {
         // Use a state machine here
         if (modtype == ModType::FM) {
           float pilot_level = fm.get_pilot_level();
-          float pilot_level_diff =
-              std::abs(pilot_level - pilot_level_average.average());
           pilot_level_average.feed(pilot_level);
           bool stereo_status = fm.stereo_detected();
           switch (pilot_status) {
           case PilotState::NotDetected:
             if (stereo_status) {
-              fprintf(stderr, "\ngot stereo signal, pilot level = %.7f\n",
-                      pilot_level);
+              fprintf(stderr, "\ngot stereo signal\n");
               pilot_status = PilotState::Detected;
               pilot_level_average.fill(0.0f);
             }
@@ -1004,24 +1001,6 @@ int main(int argc, char **argv) {
             if (!stereo_status) {
               fprintf(stderr, "\nlost stereo signal\n");
               pilot_status = PilotState::NotDetected;
-            } else {
-              if (pilot_level_diff < pilot_level_threshold) {
-                fprintf(stderr, "\npilot level stabilized to %.7f\n",
-                        pilot_level);
-                pilot_status = PilotState::Stabilized;
-              }
-            }
-            break;
-          case PilotState::Stabilized:
-            if (!stereo_status) {
-              fprintf(stderr, "\nlost stereo signal\n");
-              pilot_status = PilotState::NotDetected;
-            } else {
-              if (pilot_level_diff >= pilot_level_threshold) {
-                fprintf(stderr, "\npilot level destabilized to %.7f\n",
-                        pilot_level);
-                pilot_status = PilotState::Detected;
-              }
             }
             break;
           }


### PR DESCRIPTION
Remove the FM stereo pilot level stabilization announcement
- The pilot level display is already always available