### PR TITLE
Fix potential bugs of clang-tidy warnings

### DIFF
--- a/include/AirspyHFSource.h
+++ b/include/AirspyHFSource.h
@@ -24,6 +24,7 @@
 #include <cstdint>
 #include <string>
 #include <vector>
+#include <thread>
 
 #include "Source.h"
 

--- a/include/AirspyHFSource.h
+++ b/include/AirspyHFSource.h
@@ -23,8 +23,8 @@
 #include "libairspyhf/airspyhf.h"
 #include <cstdint>
 #include <string>
-#include <vector>
 #include <thread>
+#include <vector>
 
 #include "Source.h"
 

--- a/include/AirspySource.h
+++ b/include/AirspySource.h
@@ -23,8 +23,8 @@
 #include "libairspy/airspy.h"
 #include <cstdint>
 #include <string>
-#include <vector>
 #include <thread>
+#include <vector>
 
 #include "Source.h"
 

--- a/include/AirspySource.h
+++ b/include/AirspySource.h
@@ -24,6 +24,7 @@
 #include <cstdint>
 #include <string>
 #include <vector>
+#include <thread>
 
 #include "Source.h"
 

--- a/include/AmDecode.h
+++ b/include/AmDecode.h
@@ -21,11 +21,9 @@
 #define INCLUDE_AMDECODE_H
 
 #include "AfSimpleAgc.h"
-#include "AudioResampler.h"
 #include "Filter.h"
 #include "FilterParameters.h"
 #include "FineTuner.h"
-#include "FourthConverterIQ.h"
 #include "IfResampler.h"
 #include "IfSimpleAgc.h"
 #include "SoftFM.h"

--- a/include/AudioOutput.h
+++ b/include/AudioOutput.h
@@ -20,7 +20,6 @@
 #ifndef INCLUDE_AUDIOOUTPUT_H
 #define INCLUDE_AUDIOOUTPUT_H
 
-#include <cstdio>
 #include <string>
 
 #include "SoftFM.h"

--- a/include/MovingAverage.h
+++ b/include/MovingAverage.h
@@ -20,7 +20,6 @@
 #ifndef INCLUDE_MOVINGAVERAGE_H
 #define INCLUDE_MOVINGAVERAGE_H
 
-#include <stdint.h>
 #include <vector>
 
 template <class Type> class MovingAverage {

--- a/include/NbfmDecode.h
+++ b/include/NbfmDecode.h
@@ -19,9 +19,6 @@
 #ifndef INCLUDE_NBFMDECODE_H
 #define INCLUDE_NBFMDECODE_H
 
-#include <cstdint>
-
-#include "AudioResampler.h"
 #include "Filter.h"
 #include "FilterParameters.h"
 #include "IfSimpleAgc.h"

--- a/include/PilotPhaseLock.h
+++ b/include/PilotPhaseLock.h
@@ -20,12 +20,7 @@
 #ifndef INCLUDE_PILOTPHASELOCK_H
 #define INCLUDE_PILOTPHASELOCK_H
 
-#include "AudioResampler.h"
 #include "Filter.h"
-#include "FilterParameters.h"
-#include "IfSimpleAgc.h"
-#include "MultipathFilter.h"
-#include "PhaseDiscriminator.h"
 #include "SoftFM.h"
 
 // Phase-locked loop for stereo pilot.

--- a/include/Source.h
+++ b/include/Source.h
@@ -21,7 +21,6 @@
 #define INCLUDE_SOURCE_H
 
 #include <atomic>
-#include <memory>
 #include <string>
 
 #include "DataBuffer.h"

--- a/main.cpp
+++ b/main.cpp
@@ -844,6 +844,12 @@ int main(int argc, char **argv) {
   ///////////////////////////////////////
   for (uint64_t block = 0; !stop_flag.load(); block++) {
 
+    // If the end has been reached at the source buffer,
+    // exit the main processing loop.
+    if (source_buffer.pull_end_reached()) {
+      break;
+    }
+
     // Pull next block from source buffer.
     IQSampleVector iqsamples = source_buffer.pull();
 

--- a/main.cpp
+++ b/main.cpp
@@ -847,6 +847,7 @@ int main(int argc, char **argv) {
     // If the end has been reached at the source buffer,
     // exit the main processing loop.
     if (source_buffer.pull_end_reached()) {
+      stop_flag.store(true);
       break;
     }
 

--- a/main.cpp
+++ b/main.cpp
@@ -17,9 +17,7 @@
 // You should have received a copy of the GNU General Public License along
 // with this program; if not, see http://www.gnu.org/licenses/gpl-2.0.html
 
-#include <algorithm>
 #include <atomic>
-#include <climits>
 #include <csignal>
 #include <cstdio>
 #include <cstdlib>
@@ -28,7 +26,6 @@
 #include <memory>
 #include <signal.h>
 #include <sys/time.h>
-#include <thread>
 #include <unistd.h>
 
 #include "AirspyHFSource.h"
@@ -37,7 +34,6 @@
 #include "AudioOutput.h"
 #include "DataBuffer.h"
 #include "FileSource.h"
-#include "Filter.h"
 #include "FilterParameters.h"
 #include "FineTuner.h"
 #include "FmDecode.h"

--- a/sfmbase/AirspyHFSource.cpp
+++ b/sfmbase/AirspyHFSource.cpp
@@ -17,7 +17,6 @@
 // You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-#include <algorithm>
 #include <cstdlib>
 #include <cstring>
 #include <iomanip>

--- a/sfmbase/AirspyHFSource.cpp
+++ b/sfmbase/AirspyHFSource.cpp
@@ -297,7 +297,7 @@ bool AirspyHFSource::configure(std::string configurationStr) {
       return false;
     }
 
-    int samplerate;
+    int samplerate = 0;
     bool samplerate_ok =
         Utility::parse_int(m["srate"].c_str(), samplerate, true);
     m_sampleRate = static_cast<uint32_t>(samplerate);
@@ -314,7 +314,7 @@ bool AirspyHFSource::configure(std::string configurationStr) {
     std::cerr << "AirspyHFSource::configure: freq: " << m["freq"] << std::endl;
 #endif
 
-    int freq;
+    int freq = 0;
     bool freq_ok = Utility::parse_int(m["freq"].c_str(), freq, true);
     frequency = static_cast<uint32_t>(freq);
 
@@ -331,7 +331,7 @@ bool AirspyHFSource::configure(std::string configurationStr) {
               << std::endl;
 #endif
 
-    int attlevel;
+    int attlevel = 0;
     bool attlevel_ok = Utility::parse_int(m["hf_att"].c_str(), attlevel);
     hfAttLevel = static_cast<uint8_t>(attlevel);
     if (!attlevel_ok || (hfAttLevel > 8) || (hfAttLevel < 0)) {

--- a/sfmbase/AirspyHFSource.cpp
+++ b/sfmbase/AirspyHFSource.cpp
@@ -297,10 +297,12 @@ bool AirspyHFSource::configure(std::string configurationStr) {
       return false;
     }
 
-    m_sampleRate = atoi(m["srate"].c_str());
-
+    int samplerate;
+    bool samplerate_ok =
+        Utility::parse_int(m["srate"].c_str(), samplerate, true);
+    m_sampleRate = static_cast<uint32_t>(samplerate);
     sampleRateIndex = check_sampleRateIndex(m_sampleRate);
-    if (sampleRateIndex == -1) {
+    if (sampleRateIndex == -1 || !samplerate_ok) {
       m_error = "Invalid sample rate";
       m_sampleRate = 0;
       return false;
@@ -311,9 +313,12 @@ bool AirspyHFSource::configure(std::string configurationStr) {
 #ifdef DEBUG_AIRSPYHFSOURCE
     std::cerr << "AirspyHFSource::configure: freq: " << m["freq"] << std::endl;
 #endif
-    frequency = atoi(m["freq"].c_str());
 
-    if (((frequency > 31000000) && (frequency < 60000000)) ||
+    int freq;
+    bool freq_ok = Utility::parse_int(m["freq"].c_str(), freq, true);
+    frequency = static_cast<uint32_t>(freq);
+
+    if (!freq_ok || ((frequency > 31000000) && (frequency < 60000000)) ||
         (frequency > 260000000)) {
       m_error = "Invalid frequency";
       return false;
@@ -325,9 +330,11 @@ bool AirspyHFSource::configure(std::string configurationStr) {
     std::cerr << "AirspyHFSource::configure: hf_att: " << m["hf_att"]
               << std::endl;
 #endif
-    hfAttLevel = atoi(m["hf_att"].c_str());
 
-    if ((hfAttLevel > 8) || (hfAttLevel < 0)) {
+    int attlevel;
+    bool attlevel_ok = Utility::parse_int(m["hf_att"].c_str(), attlevel);
+    hfAttLevel = static_cast<uint8_t>(attlevel);
+    if (!attlevel_ok || (hfAttLevel > 8) || (hfAttLevel < 0)) {
       m_error = "Invalid HF att level";
       return false;
     }

--- a/sfmbase/AirspySource.cpp
+++ b/sfmbase/AirspySource.cpp
@@ -330,17 +330,19 @@ bool AirspySource::configure(std::string configurationStr) {
       return false;
     }
 
-    m_sampleRate = atoi(m["srate"].c_str());
-    uint32_t i;
+    int samplerate = 0;
+    bool samplerate_ok =
+        Utility::parse_int(m["srate"].c_str(), samplerate, true);
+    m_sampleRate = static_cast<uint32_t>(samplerate);
 
+    uint32_t i;
     for (i = 0; i < m_srates.size(); i++) {
       if (m_srates[i] == static_cast<int>(m_sampleRate)) {
         sampleRateIndex = i;
         break;
       }
     }
-
-    if (i == m_srates.size()) {
+    if (i == m_srates.size() || !samplerate_ok) {
       m_error = "Invalid sample rate";
       m_sampleRate = 0;
       return false;
@@ -351,9 +353,11 @@ bool AirspySource::configure(std::string configurationStr) {
 #ifdef DEBUG_AIRSPYSOURCE
     std::cerr << "AirspySource::configure: freq: " << m["freq"] << std::endl;
 #endif
-    frequency = atoi(m["freq"].c_str());
+    int freq = 0;
+    bool freq_ok = Utility::parse_int(m["freq"].c_str(), freq, true);
+    frequency = static_cast<uint32_t>(freq);
 
-    if ((frequency < 24000000) || (frequency > 1800000000)) {
+    if (!freq_ok || (frequency < 24000000) || (frequency > 1800000000)) {
       m_error = "Invalid frequency";
       return false;
     }
@@ -368,9 +372,9 @@ bool AirspySource::configure(std::string configurationStr) {
       return false;
     }
 
-    lnaGain = atoi(m["lgain"].c_str());
-
-    if (find(m_lgains.begin(), m_lgains.end(), lnaGain) == m_lgains.end()) {
+    bool lgain_ok = Utility::parse_int(m["lgain"].c_str(), lnaGain);
+    if (!lgain_ok ||
+        find(m_lgains.begin(), m_lgains.end(), lnaGain) == m_lgains.end()) {
       m_error = "LNA gain not supported. Available gains (dB): " + m_lgainsStr;
       return false;
     }
@@ -385,9 +389,9 @@ bool AirspySource::configure(std::string configurationStr) {
       return false;
     }
 
-    mixGain = atoi(m["mgain"].c_str());
-
-    if (find(m_mgains.begin(), m_mgains.end(), mixGain) == m_mgains.end()) {
+    bool mgain_ok = Utility::parse_int(m["mgain"].c_str(), mixGain);
+    if (!mgain_ok ||
+        find(m_mgains.begin(), m_mgains.end(), mixGain) == m_mgains.end()) {
       m_error =
           "Mixer gain not supported. Available gains (dB): " + m_mgainsStr;
       return false;
@@ -398,14 +402,14 @@ bool AirspySource::configure(std::string configurationStr) {
 #ifdef DEBUG_AIRSPYSOURCE
     std::cerr << "AirspySource::configure: vgain: " << m["vgain"] << std::endl;
 #endif
-    vgaGain = atoi(m["vgain"].c_str());
-
     if (strcasecmp(m["vgain"].c_str(), "list") == 0) {
       m_error = "Available VGA gains (dB): " + m_vgainsStr;
       return false;
     }
 
-    if (find(m_vgains.begin(), m_vgains.end(), vgaGain) == m_vgains.end()) {
+    bool vgain_ok = Utility::parse_int(m["vgain"].c_str(), vgaGain);
+    if (!vgain_ok ||
+        find(m_vgains.begin(), m_vgains.end(), vgaGain) == m_vgains.end()) {
       m_error = "VGA gain not supported. Available gains (dB): " + m_vgainsStr;
       return false;
     }

--- a/sfmbase/AudioOutput.cpp
+++ b/sfmbase/AudioOutput.cpp
@@ -20,7 +20,6 @@
 #include "sndfile.h"
 #define _FILE_OFFSET_BITS 64
 
-#include <algorithm>
 #include <cerrno>
 #include <cstdio>
 #include <cstring>

--- a/sfmbase/AudioOutput.cpp
+++ b/sfmbase/AudioOutput.cpp
@@ -18,7 +18,6 @@
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 #include "sndfile.h"
-#define _FILE_OFFSET_BITS 64
 
 #include <cerrno>
 #include <cstdio>

--- a/sfmbase/FileSource.cpp
+++ b/sfmbase/FileSource.cpp
@@ -25,7 +25,6 @@
 
 #include "ConfigParser.h"
 #include "FileSource.h"
-#include "Utility.h"
 
 FileSource *FileSource::m_this = 0;
 

--- a/sfmbase/FileSource.cpp
+++ b/sfmbase/FileSource.cpp
@@ -73,7 +73,6 @@ bool FileSource::configure(std::string configurationStr) {
 
   // srate
   if (m.find("srate") != m.end()) {
-    std::cerr << "FileSource::configure: srate: " << m["srate"] << std::endl;
     int samplerate = 0;
     bool samplerate_ok =
         Utility::parse_int(m["srate"].c_str(), samplerate, true);
@@ -83,11 +82,11 @@ bool FileSource::configure(std::string configurationStr) {
       std::cerr << "FileSource::configure: invalid samplerate" << std::endl;
       return false;
     }
+    std::cerr << "FileSource::configure: srate: " << sample_rate << std::endl;
   }
 
   // freq
   if (m.find("freq") != m.end()) {
-    std::cerr << "FileSource::configure: freq: " << m["freq"] << std::endl;
     int freq = 0;
     bool freq_ok = Utility::parse_int(m["freq"].c_str(), freq, true);
     frequency = static_cast<uint32_t>(freq);
@@ -95,16 +94,17 @@ bool FileSource::configure(std::string configurationStr) {
       std::cerr << "FileSource::configure: invalid frequency" << std::endl;
       return false;
     }
+    std::cerr << "FileSource::configure: freq: " << frequency  << std::endl;
   }
 
   // blklen
   if (m.find("blklen") != m.end()) {
-    std::cerr << "FileSource::configure: blklen: " << m["blklen"] << std::endl;
     bool blklen_ok = Utility::parse_int(m["blklen"].c_str(), block_length);
     if (!blklen_ok) {
       std::cerr << "FileSource::configure: invalid blklen" << std::endl;
       return false;
     }
+    std::cerr << "FileSource::configure: blklen: " << block_length << std::endl;
   }
 
   // zero_offset

--- a/sfmbase/FileSource.cpp
+++ b/sfmbase/FileSource.cpp
@@ -25,6 +25,7 @@
 
 #include "ConfigParser.h"
 #include "FileSource.h"
+#include "Utility.h"
 
 FileSource *FileSource::m_this = 0;
 
@@ -73,20 +74,37 @@ bool FileSource::configure(std::string configurationStr) {
   // srate
   if (m.find("srate") != m.end()) {
     std::cerr << "FileSource::configure: srate: " << m["srate"] << std::endl;
-    sample_rate = atoi(m["srate"].c_str());
+    int samplerate = 0;
+    bool samplerate_ok =
+        Utility::parse_int(m["srate"].c_str(), samplerate, true);
+    sample_rate = static_cast<uint32_t>(samplerate);
     srate_specified = true;
+    if (!samplerate_ok) {
+      std::cerr << "FileSource::configure: invalid samplerate" << std::endl;
+      return false;
+    }
   }
 
   // freq
   if (m.find("freq") != m.end()) {
     std::cerr << "FileSource::configure: freq: " << m["freq"] << std::endl;
-    frequency = atoi(m["freq"].c_str());
+    int freq = 0;
+    bool freq_ok = Utility::parse_int(m["freq"].c_str(), freq, true);
+    frequency = static_cast<uint32_t>(freq);
+    if (!freq_ok) {
+      std::cerr << "FileSource::configure: invalid frequency" << std::endl;
+      return false;
+    }
   }
 
   // blklen
   if (m.find("blklen") != m.end()) {
     std::cerr << "FileSource::configure: blklen: " << m["blklen"] << std::endl;
-    block_length = atoi(m["blklen"].c_str());
+    bool blklen_ok = Utility::parse_int(m["blklen"].c_str(), block_length);
+    if (!blklen_ok) {
+      std::cerr << "FileSource::configure: invalid blklen" << std::endl;
+      return false;
+    }
   }
 
   // zero_offset

--- a/sfmbase/FileSource.cpp
+++ b/sfmbase/FileSource.cpp
@@ -94,7 +94,7 @@ bool FileSource::configure(std::string configurationStr) {
       std::cerr << "FileSource::configure: invalid frequency" << std::endl;
       return false;
     }
-    std::cerr << "FileSource::configure: freq: " << frequency  << std::endl;
+    std::cerr << "FileSource::configure: freq: " << frequency << std::endl;
   }
 
   // blklen

--- a/sfmbase/IfSimpleAgc.cpp
+++ b/sfmbase/IfSimpleAgc.cpp
@@ -17,7 +17,6 @@
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 #include "IfSimpleAgc.h"
-#include "Utility.h"
 
 // class IfSimpleAgc
 

--- a/sfmbase/RtlSdrSource.cpp
+++ b/sfmbase/RtlSdrSource.cpp
@@ -88,23 +88,26 @@ bool RtlSdrSource::configure(std::string configurationStr) {
 
   cp.parse_config_string(configurationStr, m);
   if (m.find("srate") != m.end()) {
-    std::cerr << "RtlSdrSource::configure: srate: " << m["srate"] << std::endl;
-    sample_rate = atoi(m["srate"].c_str());
-
-    if ((sample_rate < 900001) || (sample_rate > 3200000)) {
+    int samplerate = 0;
+    bool samplerate_ok =
+        Utility::parse_int(m["srate"].c_str(), samplerate, true);
+    sample_rate = static_cast<uint32_t>(samplerate);
+    if (!samplerate_ok || (sample_rate < 900001) || (sample_rate > 3200000)) {
       m_error = "Invalid sample rate";
       return false;
     }
+    std::cerr << "RtlSdrSource::configure: srate: " << sample_rate << std::endl;
   }
 
   if (m.find("freq") != m.end()) {
-    std::cerr << "RtlSdrSource::configure: freq: " << m["freq"] << std::endl;
-    frequency = atoi(m["freq"].c_str());
-
-    if ((frequency < 10000000) || (frequency > 2200000000)) {
+    int freq = 0;
+    bool freq_ok = Utility::parse_int(m["freq"].c_str(), freq, true);
+    frequency = static_cast<uint32_t>(freq);
+    if (!freq_ok || (frequency < 10000000) || (frequency > 2200000000)) {
       m_error = "Invalid frequency";
       return false;
     }
+    std::cerr << "RtlSdrSource::configure: freq: " << frequency << std::endl;
   }
 
   if (m.find("gain") != m.end()) {
@@ -142,9 +145,13 @@ bool RtlSdrSource::configure(std::string configurationStr) {
   } // gain
 
   if (m.find("blklen") != m.end()) {
-    std::cerr << "RtlSdrSource::configure: blklen: " << m["blklen"]
+    bool blklen_ok = Utility::parse_int(m["blklen"].c_str(), block_length);
+    if (!blklen_ok) {
+      std::cerr << "RtlSdrSource::configure: invalid blklen" << std::endl;
+      return false;
+    }
+    std::cerr << "RtlSdrSource::configure: blklen: " << block_length
               << std::endl;
-    block_length = atoi(m["blklen"].c_str());
   }
 
   if (m.find("agc") != m.end()) {


### PR DESCRIPTION
Bugfix:

* [Add missing `<thread>` headers](https://github.com/jj1bdx/airspy-fmradion/commit/75f47072836c0a18db9f9f511642564a8dbe22ef)
* [main.cpp: check pull_end_reached() in the main loop](https://github.com/jj1bdx/airspy-fmradion/commit/6a2d1b70f4f036c6d98191a610b435cfa7e8d2fc)
  - FileSource driver could not terminate the main loop when the end-of-file was reached
* Remove unused `#include` header directives

Fixed the errors detected by clang-tidy, listed in the following CMU SEI C++ Coding Standard sections:

* [ERR34-C. Detect errors when converting a string to a number](https://wiki.sei.cmu.edu/confluence/display/c/ERR34-C.+Detect+errors+when+converting+a+string+to+a+number)
  - Use `Utility::parse_int()` instead of raw `atoi()`
* [DCL51-CPP. Do not declare or define a reserved identifier](https://wiki.sei.cmu.edu/confluence/display/cplusplus/DCL51-CPP.+Do+not+declare+or+define+a+reserved+identifier)
  - Remove unused `_FILE_OFFSET_BITS`
