### PR TITLE
Remove FM AFC code

### DIFF
--- a/README.md
+++ b/README.md
@@ -226,7 +226,6 @@ install -o user -m 0700 -c -s build/airspy-fmradion $(HOME)/bin
  - `-l dB` Enable IF squelch, set the level to minus given value of dB
  - `-E stages` Enable multipath filter for FM (For stable reception only: turn off if reception becomes unstable)
  - `-r ppm` Set IF offset in ppm (range: +-1000000ppm) (Note: this option affects output pitch and timing: *use for the output timing compensation only!*
- - `-A` (For FM only) Experimental 10Hz-step IF AFC
 
 ## Major changes
 

--- a/main.cpp
+++ b/main.cpp
@@ -843,7 +843,6 @@ int main(int argc, char **argv) {
     // Pull next block from source buffer.
     IQSampleVector iqsamples = source_buffer.pull();
 
-    IQSampleVector if_afc_samples;
     IQSampleVector if_shifted_samples;
     IQSampleVector if_downsampled_samples;
     IQSampleVector if_samples;


### PR DESCRIPTION
FM AFC code is not really necessary when SDR frontend oscillators are TCXO.