### PR TITLE
Change VOLK version display format

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -330,7 +330,8 @@ int main(int argc, char **argv) {
   } else {
     fprintf(stderr, "Git commit unknown\n");
   }
-  fprintf(stderr, "VOLK_VERSION = %.6o\n", VOLK_VERSION);
+  fprintf(stderr, "VOLK Version = %u.%u.%u\n", VOLK_VERSION_MAJOR,
+          VOLK_VERSION_MINOR, VOLK_VERSION_MAINT);
 
   const struct option longopts[] = {
       {"modtype", optional_argument, nullptr, 'm'},


### PR DESCRIPTION
The `VOLK_VERSION` value has lost the `0` prefix since v3.1.1, which caused an error in showing the value as an *octal* number. In this pull request, the version string is updated as "`VOLK_VERSION_MAJOR`.`VOLK_VERSION_MINOR`.`VOLK_VERSION_MAINT`", representing the semantic version string. This solves the incomprehensible version number display issue.
