### PR TITLE
Set PortAudio default latency time to 40ms

### DIFF
--- a/include/AudioOutput.h
+++ b/include/AudioOutput.h
@@ -98,6 +98,18 @@ private:
 
 class PortAudioOutput : public AudioOutput {
 public:
+  // Static variables.
+
+  // Minimum latency for audio output in seconds
+
+  // Values of m_outputparams.suggestedLatency from PortAudio:
+  // Mac mini 2023 with macOS 14.3.1: 0.014717
+  // Ubuntu 22.04.4 on x86_64: 0.034830
+  // Kenji's experiments show that
+  // 40ms (0.04) is sufficient for macOS, Ubuntu, and Raspberry Pi OS
+
+  static constexpr PaTime minimum_latency = 0.04;
+
   //
   // Construct PortAudio output stream.
   //

--- a/sfmbase/AudioOutput.cpp
+++ b/sfmbase/AudioOutput.cpp
@@ -164,6 +164,13 @@ PortAudioOutput::PortAudioOutput(const PaDeviceIndex device_index,
       Pa_GetDeviceInfo(m_outputparams.device)->defaultHighOutputLatency;
   m_outputparams.hostApiSpecificStreamInfo = NULL;
 
+  // values of m_outputparams.suggestedLatency from PortAudio:
+  // Mac mini 2023 with macOS 14.3.1: 0.014717
+  // Ubuntu 22.04.4 on x86_64: 0.034830
+  if (m_outputparams.suggestedLatency < 0.04) {
+    m_outputparams.suggestedLatency = 0.04;
+  }
+
   m_paerror =
       Pa_OpenStream(&m_stream,
                     NULL, // no input
@@ -179,7 +186,6 @@ PortAudioOutput::PortAudioOutput(const PaDeviceIndex device_index,
 
   fprintf(stderr, "suggestedLatency = %f\n", m_outputparams.suggestedLatency);
 
-  
   m_paerror = Pa_StartStream(m_stream);
   if (m_paerror != paNoError) {
     add_paerror("Pa_StartStream()");

--- a/sfmbase/AudioOutput.cpp
+++ b/sfmbase/AudioOutput.cpp
@@ -177,6 +177,9 @@ PortAudioOutput::PortAudioOutput(const PaDeviceIndex device_index,
     return;
   }
 
+  fprintf(stderr, "suggestedLatency = %f\n", m_outputparams.suggestedLatency);
+
+  
   m_paerror = Pa_StartStream(m_stream);
   if (m_paerror != paNoError) {
     add_paerror("Pa_StartStream()");

--- a/sfmbase/AudioOutput.cpp
+++ b/sfmbase/AudioOutput.cpp
@@ -164,12 +164,12 @@ PortAudioOutput::PortAudioOutput(const PaDeviceIndex device_index,
       Pa_GetDeviceInfo(m_outputparams.device)->defaultHighOutputLatency;
   m_outputparams.hostApiSpecificStreamInfo = NULL;
 
-  // values of m_outputparams.suggestedLatency from PortAudio:
-  // Mac mini 2023 with macOS 14.3.1: 0.014717
-  // Ubuntu 22.04.4 on x86_64: 0.034830
-  if (m_outputparams.suggestedLatency < 0.04) {
-    m_outputparams.suggestedLatency = 0.04;
+  // Guarantee minimum latency.
+  if (m_outputparams.suggestedLatency < minimum_latency) {
+    m_outputparams.suggestedLatency = minimum_latency;
   }
+
+  fprintf(stderr, "suggestedLatency = %f\n", m_outputparams.suggestedLatency);
 
   m_paerror =
       Pa_OpenStream(&m_stream,
@@ -183,8 +183,6 @@ PortAudioOutput::PortAudioOutput(const PaDeviceIndex device_index,
     add_paerror("Pa_OpenStream()");
     return;
   }
-
-  fprintf(stderr, "suggestedLatency = %f\n", m_outputparams.suggestedLatency);
 
   m_paerror = Pa_StartStream(m_stream);
   if (m_paerror != paNoError) {


### PR DESCRIPTION
Running airspy-fmradion on a Mac mini 2023 (M2 Pro) with macOS 14.3.1 showed sound disruption when a process consuming a considerable switching time, such as web browsers, was invoked. The latency time was 14.7ms. The latency time on a Ubuntu 22.04.4 was 34.8ms. Setting the latency time to 40ms will solve most, if not all, of the disruption problem.