### PR TITLE
Add MP3 output file capability

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -43,7 +43,7 @@ else()
     find_library(VOLK_LIBRARY libvolk.so
 	HINTS ${PKG_VOLK_LIBRARY_DIRS})
 endif()
-message(STATUS "volk library: ${VOLK_LIBRARY}")
+message(STATUS "volk ${PKG_VOLK_VERSION}: ${VOLK_LIBRARY}")
 
 # Find Airspy library.
 pkg_check_modules(PKG_AIRSPY libairspy)
@@ -64,7 +64,7 @@ else()
 	    HINTS ${PKG_AIRSPY_LIBRARY_DIRS})
     set(AIRSPY_INCLUDE_OPTION "")
 endif()
-message(STATUS "libairspy: ${AIRSPY_INCLUDE_DIR}, ${AIRSPY_LIBRARY}")
+message(STATUS "libairspy ${PKG_AIRSPY_VERSION}: ${AIRSPY_INCLUDE_DIR}, ${AIRSPY_LIBRARY}")
 
 # Find Airspy HF library.
 pkg_check_modules(PKG_AIRSPYHF libairspyhf)
@@ -85,7 +85,7 @@ else()
              HINT ${PKG_AIRSPYHF_LIBRARY_DIRS})
     set(AIRSPYHF_INCLUDE_OPTION "")
 endif()
-message(STATUS "libairspyhf: ${AIRSPYHF_INCLUDE_DIR}, ${AIRSPYHF_LIBRARY}")
+message(STATUS "libairspyhf ${PKG_AIRSPYHF_VERSION}: ${AIRSPYHF_INCLUDE_DIR}, ${AIRSPYHF_LIBRARY}")
 
 # Find RTL-SDR library.
 pkg_check_modules(PKG_RTLSDR librtlsdr)
@@ -93,7 +93,7 @@ find_path(RTLSDR_INCLUDE_DIR rtl-sdr.h
 	HINTS ${PKG_RTLSDR_INCLUDE_DIRS})
 find_library(RTLSDR_LIBRARY librtlsdr.a
 	HINTS ${PKG_RTLSDR_LIBRARY_DIRS})
-message(STATUS "librtlsdr: ${RTLSDR_INCLUDE_DIR}, ${RTLSDR_LIBRARY}")
+message(STATUS "librtlsdr ${PKG_RTLSDR_VERSION}: ${RTLSDR_INCLUDE_DIR}, ${RTLSDR_LIBRARY}")
 
 # Find libusb
 # See https://github.com/texane/stlink/blob/master/cmake/modules/FindLibUSB.cmake
@@ -104,14 +104,19 @@ find_path(LIBUSB_INCLUDE_DIR libusb.h
 set(LIBUSB_NAME usb-1.0)
 find_library(LIBUSB_LIBRARY ${LIBUSB_NAME}
     HINTS /usr /usr/local /opt /opt/homebrew ${PKG_LIBUSB_LIBRARY_DIRS})
-message(STATUS "libusb: ${LIBUSB_INCLUDE_DIR}, ${LIBUSB_LIBRARY}")
+message(STATUS "libusb ${PKG_LIBUSB_VERSION}: ${LIBUSB_INCLUDE_DIR}, ${LIBUSB_LIBRARY}")
 
-# Find sndfile library.
-FIND_LIBRARY(SNDFILE_LIBRARY sndfile)
-
-FIND_PATH(SNDFILE_INCLUDE_DIR sndfile.h
+# Find sndfile library
+pkg_check_modules(PKG_SNDFILE sndfile)
+find_path(SNDFILE_INCLUDE_DIR sndfile.h
 	HINTS ${PKG_SNDFILE_INCLUDE_DIRS})
-MESSAGE(STATUS "Sndfile: ${SNDFILE_LIBRARY}, ${SNDFILE_INCLUDE_DIR}")
+find_library(SNDFILE_LIBRARY sndfile)
+message(STATUS "sndfile ${PKG_SNDFILE_VERSION}: ${SNDFILE_LIBRARY}, ${SNDFILE_INCLUDE_DIR}")
+# Determine MP3 support on sndfile
+if(PKG_SNDFILE_VERSION VERSION_GREATER_EQUAL "1.1")
+  SET(SNDFILE_INCLUDE_OPTION "-DLIBSNDFILE_MP3_ENABLED")
+  message(STATUS "sndfile MP3 support enabled")
+endif()
 
 # for PortAudio
 pkg_check_modules(PORTAUDIO2 portaudio-2.0)
@@ -136,21 +141,11 @@ if (PORTAUDIO2_FOUND)
 else (PORTAUDIO2_FOUND)
     message(FATAL_ERROR "Could not find Portaudio")
 endif (PORTAUDIO2_FOUND)
-message(STATUS "libportaudio: ${PORTAUDIO_INCLUDE_DIR}, ${PORTAUDIO_LIBRARY}")
+message(STATUS "libportaudio ${PORTAUDIO2_VERSION}: ${PORTAUDIO_INCLUDE_DIR}, ${PORTAUDIO_LIBRARY}")
 message(STATUS "PortAudio libs: ${PORTAUDIO_LINK_LIBRARIES}")
-
-if(RTLSDR_INCLUDE_DIR AND RTLSDR_LIBRARY)
-    message(STATUS "Found librtlsdr: ${RTLSDR_INCLUDE_DIR}, ${RTLSDR_LIBRARY}")
-else()
-    message(WARNING "Can not find Osmocom RTL-SDR library")
-    message("Try again with environment variable PKG_CONFIG_PATH")
-    message("or with -DRTLSDR_INCLUDE_DIR=/path/rtlsdr/include")
-    message("        -DRTLSDR_LIBRARY=/path/rtlsdr/lib/librtlsdr.a")
-endif()
 
 set(RTLSDR_INCLUDE_DIRS ${RTLSDR_INCLUDE_DIR} ${LIBUSB_INCLUDE_DIR})
 set(RTLSDR_LIBRARIES    ${RTLSDR_LIBRARY} ${LIBUSB_LIBRARY})
-
 set(AIRSPY_INCLUDE_DIRS ${AIRSPY_INCLUDE_DIR} ${LIBUSB_INCLUDE_DIR})
 set(AIRSPY_LIBRARIES    ${AIRSPY_LIBRARY} ${LIBUSB_LIBRARY})
 set(AIRSPYHF_INCLUDE_DIRS ${AIRSPYHF_INCLUDE_DIR} ${LIBUSB_INCLUDE_DIR})
@@ -184,7 +179,7 @@ set(OPTIMIZATION_FLAGS "-O3 -ftree-vectorize ")
 
 # Common compiler flags and options.
 ##
-set(CMAKE_CXX_FLAGS "-Wall -std=c++17 ${OPTIMIZATION_FLAGS} ${AIRSPY_INCLUDE_OPTION} ${AIRSPYHF_INCLUDE_OPTION} ${EXTRA_FLAGS}")
+set(CMAKE_CXX_FLAGS "-Wall -std=c++17 ${OPTIMIZATION_FLAGS} ${AIRSPY_INCLUDE_OPTION} ${AIRSPYHF_INCLUDE_OPTION} ${SNDFILE_INCLUDE_OPTION} ${EXTRA_FLAGS}")
 
 # For building airspy-fmradion sources
 

--- a/include/AudioOutput.h
+++ b/include/AudioOutput.h
@@ -89,6 +89,9 @@ public:
   virtual void output_close() override;
 
 private:
+  // Add sndfile log info to m_error and set m_zombie flag
+  void add_error_log_info(SNDFILE *sf);
+
   const unsigned numberOfChannels;
   const unsigned sampleRate;
   int m_fd;

--- a/include/SoftFM.h
+++ b/include/SoftFM.h
@@ -52,7 +52,9 @@ enum class OutputMode {
   WAV_INT16,
   WAV_FLOAT32,
   PORTAUDIO,
+#if defined(LIBSNDFILE_MP3_ENABLED)
   MP3_FMAUDIO
+#endif // LIBSNDFILE_MP3_ENABLED
 };
 enum class PilotState { NotDetected, Detected };
 

--- a/include/SoftFM.h
+++ b/include/SoftFM.h
@@ -51,7 +51,8 @@ enum class OutputMode {
   RAW_FLOAT32,
   WAV_INT16,
   WAV_FLOAT32,
-  PORTAUDIO
+  PORTAUDIO,
+  MP3_FMAUDIO
 };
 enum class PilotState { NotDetected, Detected };
 

--- a/main.cpp
+++ b/main.cpp
@@ -88,6 +88,9 @@ static void usage() {
       "  -G filename    Write audio data to RF64/WAV FLOAT_LE file\n"
       "                 use filename '-' to write to stdout\n"
       "                 (Pipe is not supported)\n"
+      "  -C filename    Write audio data to MP3 file\n"
+      "                 of 192kbps CBR (EXPERIMENTAL)\n"
+      "                 use filename '-' to write to stdout\n"
       "  -P device_num  Play audio via PortAudio device index number\n"
       "                 use string '-' to specify the default PortAudio "
       "device\n"
@@ -352,10 +355,11 @@ int main(int argc, char **argv) {
       {"squelch", required_argument, nullptr, 'l'},
       {"multipathfilter", required_argument, nullptr, 'E'},
       {"ifrateppm", optional_argument, nullptr, 'r'},
+      {"mp3fmaudio", required_argument, nullptr, 'C'},
       {nullptr, no_argument, nullptr, 0}};
 
   int c, longindex;
-  while ((c = getopt_long(argc, argv, "m:t:c:d:MR:F:W:G:f:l:P:T:qXUE:r:",
+  while ((c = getopt_long(argc, argv, "m:t:c:d:MR:F:W:G:f:l:P:T:qXUE:r:C:",
                           longopts, &longindex)) >= 0) {
     switch (c) {
     case 'm':
@@ -434,6 +438,10 @@ int main(int argc, char **argv) {
           std::fabs(ifrate_offset_ppm) > 1000000.0) {
         badarg("-r");
       }
+      break;
+    case 'C':
+      outmode = OutputMode::MP3_FMAUDIO;
+      filename = optarg;
       break;
     default:
       usage();
@@ -589,6 +597,12 @@ int main(int argc, char **argv) {
       fprintf(stderr, "playing audio to PortAudio device %d: ", portaudiodev);
     }
     fprintf(stderr, "name '%s'\n", audio_output->get_device_name().c_str());
+    break;
+  case OutputMode::MP3_FMAUDIO:
+    audio_output.reset(new SndfileOutput(
+        filename, pcmrate, stereo, SF_FORMAT_MPEG | SF_FORMAT_MPEG_LAYER_III));
+    fprintf(stderr, "writing MP3 FM-broadcast audio samples to '%s'\n",
+            filename.c_str());
     break;
   }
 

--- a/main.cpp
+++ b/main.cpp
@@ -89,7 +89,7 @@ static void usage() {
       "                 use filename '-' to write to stdout\n"
       "                 (Pipe is not supported)\n"
       "  -C filename    Write audio data to MP3 file\n"
-      "                 of 192kbps CBR (EXPERIMENTAL)\n"
+      "                 of VBR -V 1 (experimental)\n"
       "                 use filename '-' to write to stdout\n"
       "  -P device_num  Play audio via PortAudio device index number\n"
       "                 use string '-' to specify the default PortAudio "

--- a/main.cpp
+++ b/main.cpp
@@ -88,9 +88,11 @@ static void usage() {
       "  -G filename    Write audio data to RF64/WAV FLOAT_LE file\n"
       "                 use filename '-' to write to stdout\n"
       "                 (Pipe is not supported)\n"
+#if defined(LIBSNDFILE_MP3_ENABLED)
       "  -C filename    Write audio data to MP3 file\n"
       "                 of VBR -V 1 (experimental)\n"
       "                 use filename '-' to write to stdout\n"
+#endif // LIBSNDFILE_MP3_ENABLED
       "  -P device_num  Play audio via PortAudio device index number\n"
       "                 use string '-' to specify the default PortAudio "
       "device\n"
@@ -335,32 +337,44 @@ int main(int argc, char **argv) {
   }
   fprintf(stderr, "VOLK Version = %u.%u.%u\n", VOLK_VERSION_MAJOR,
           VOLK_VERSION_MINOR, VOLK_VERSION_MAINT);
+#if defined(LIBSNDFILE_MP3_ENABLED)
+  fprintf(stderr, "libsndfile MP3 support enabled\n");
+#endif // LIBSNDFILE_MP3_ENABLED
 
   const struct option longopts[] = {
-      {"modtype", optional_argument, nullptr, 'm'},
-      {"devtype", optional_argument, nullptr, 't'},
-      {"quiet", required_argument, nullptr, 'q'},
-      {"config", optional_argument, nullptr, 'c'},
-      {"dev", required_argument, nullptr, 'd'},
-      {"mono", no_argument, nullptr, 'M'},
-      {"raw", required_argument, nullptr, 'R'},
-      {"float", required_argument, nullptr, 'F'},
-      {"wav", required_argument, nullptr, 'W'},
-      {"wavfloat", required_argument, nullptr, 'G'},
-      {"play", optional_argument, nullptr, 'P'},
-      {"pps", required_argument, nullptr, 'T'},
-      {"pilotshift", no_argument, nullptr, 'X'},
-      {"usa", no_argument, nullptr, 'U'},
-      {"filtertype", optional_argument, nullptr, 'f'},
-      {"squelch", required_argument, nullptr, 'l'},
-      {"multipathfilter", required_argument, nullptr, 'E'},
-      {"ifrateppm", optional_argument, nullptr, 'r'},
-      {"mp3fmaudio", required_argument, nullptr, 'C'},
-      {nullptr, no_argument, nullptr, 0}};
+    {"modtype", optional_argument, nullptr, 'm'},
+    {"devtype", optional_argument, nullptr, 't'},
+    {"quiet", required_argument, nullptr, 'q'},
+    {"config", optional_argument, nullptr, 'c'},
+    {"dev", required_argument, nullptr, 'd'},
+    {"mono", no_argument, nullptr, 'M'},
+    {"raw", required_argument, nullptr, 'R'},
+    {"float", required_argument, nullptr, 'F'},
+    {"wav", required_argument, nullptr, 'W'},
+    {"wavfloat", required_argument, nullptr, 'G'},
+    {"play", optional_argument, nullptr, 'P'},
+    {"pps", required_argument, nullptr, 'T'},
+    {"pilotshift", no_argument, nullptr, 'X'},
+    {"usa", no_argument, nullptr, 'U'},
+    {"filtertype", optional_argument, nullptr, 'f'},
+    {"squelch", required_argument, nullptr, 'l'},
+    {"multipathfilter", required_argument, nullptr, 'E'},
+    {"ifrateppm", optional_argument, nullptr, 'r'},
+#if defined(LIBSNDFILE_MP3_ENABLED)
+    {"mp3fmaudio", required_argument, nullptr, 'C'},
+#endif // LIBSNDFILE_MP3_ENABLED
+    {nullptr, no_argument, nullptr, 0}
+  };
 
   int c, longindex;
-  while ((c = getopt_long(argc, argv, "m:t:c:d:MR:F:W:G:f:l:P:T:qXUE:r:C:",
-                          longopts, &longindex)) >= 0) {
+
+#if defined(LIBSNDFILE_MP3_ENABLED)
+  const char *optstring = "m:t:c:d:MR:F:W:G:f:l:P:T:qXUE:r:C:";
+#else  // !LIBSNDFILE_MP3_ENABLED
+  const char *optstring = "m:t:c:d:MR:F:W:G:f:l:P:T:qXUE:r:";
+#endif // LIBSNDFILE_MP3_ENABLED
+
+  while ((c = getopt_long(argc, argv, optstring, longopts, &longindex)) >= 0) {
     switch (c) {
     case 'm':
       modtype_str.assign(optarg);
@@ -439,10 +453,12 @@ int main(int argc, char **argv) {
         badarg("-r");
       }
       break;
+#if defined(LIBSNDFILE_MP3_ENABLED)
     case 'C':
       outmode = OutputMode::MP3_FMAUDIO;
       filename = optarg;
       break;
+#endif // LIBSNDFILE_MP3_ENABLED
     default:
       usage();
       fprintf(stderr, "ERROR: Invalid command line options\n");
@@ -598,12 +614,14 @@ int main(int argc, char **argv) {
     }
     fprintf(stderr, "name '%s'\n", audio_output->get_device_name().c_str());
     break;
+#if defined(LIBSNDFILE_MP3_ENABLED)
   case OutputMode::MP3_FMAUDIO:
     audio_output.reset(new SndfileOutput(
         filename, pcmrate, stereo, SF_FORMAT_MPEG | SF_FORMAT_MPEG_LAYER_III));
     fprintf(stderr, "writing MP3 FM-broadcast audio samples to '%s'\n",
             filename.c_str());
     break;
+#endif // LIBSNDFILE_MP3_ENABLED
   }
 
   if (!(*audio_output)) {

--- a/sfmbase/AudioOutput.cpp
+++ b/sfmbase/AudioOutput.cpp
@@ -88,6 +88,7 @@ SndfileOutput::SndfileOutput(const std::string &filename,
     }
   }
 
+#if defined(LIBSNDFILE_MP3_ENABLED)
   // Set MP3 parameters here
   if (filetype == SF_FORMAT_MPEG) {
     fprintf(stderr, "Set MP3 parameters\n");
@@ -112,6 +113,7 @@ SndfileOutput::SndfileOutput(const std::string &filename,
       return;
     }
   }
+#endif // LIBSNDFILE_MP3_ENABLED
 
   m_device_name = "SndfileOutput";
 }

--- a/sfmbase/AudioOutput.cpp
+++ b/sfmbase/AudioOutput.cpp
@@ -88,6 +88,33 @@ SndfileOutput::SndfileOutput(const std::string &filename,
     }
   }
 
+  // Set MP3 parameters here
+  if (filetype == SF_FORMAT_MPEG) {
+    fprintf(stderr, "Set MP3 parameters\n");
+    // Set MP3 default format parameters
+    // Constant bitrate mode
+    // Bitrate: 192kbps, compression level = 0.4444444444444444
+    int constant_mode = SF_BITRATE_MODE_CONSTANT;
+    double compression_level = 0.444444444444444444;
+    // NOTE: for constant bitrate,
+    // you need to set SFC_SET_COMPRESSION_LEVEL *BEFORE*
+    // executing SFC_SET_BITRATE_MODE.
+    if (SF_TRUE != sf_command(m_sndfile, SFC_SET_COMPRESSION_LEVEL,
+                              &compression_level, sizeof(double))) {
+      m_error = "unable to set SFC_SET_COMPRESSION_LEVEL on '" + filename +
+                "' (" + sf_strerror(m_sndfile) + ")";
+      m_zombie = true;
+      return;
+    }
+    if (SF_TRUE != sf_command(m_sndfile, SFC_SET_BITRATE_MODE, &constant_mode,
+                              sizeof(int))) {
+      m_error = "unable to set SFC_SET_BITRATE_MODE on '" + filename + "' (" +
+                sf_strerror(m_sndfile) + ")";
+      m_zombie = true;
+      return;
+    }
+  }
+
   m_device_name = "SndfileOutput";
 }
 

--- a/sfmbase/AudioOutput.cpp
+++ b/sfmbase/AudioOutput.cpp
@@ -91,17 +91,11 @@ SndfileOutput::SndfileOutput(const std::string &filename,
   // Set MP3 parameters here
   if (filetype == SF_FORMAT_MPEG) {
     fprintf(stderr, "Set MP3 parameters\n");
-    // Set MP3 default format parameters
-    // Constant bitrate mode
-    // Bitrate: 192kbps, compression level = 0.4444444444444444
-    //
-    // For 48kHz sampling rate, compression level x is defined as
-    // CBR_target_rate = 320.0 - (x * (320.0 - 32.0)) (in kbps)
-    //
-    int constant_mode = SF_BITRATE_MODE_CONSTANT;
-    double compression_level = 0.444444444444444444;
-    // NOTE: for constant bitrate,
-    // you need to set SFC_SET_COMPRESSION_LEVEL *BEFORE*
+    // Set MP3 default format parameters to:
+    // Variable bitrate mode, compression level = 0.1
+    int constant_mode = SF_BITRATE_MODE_VARIABLE;
+    double compression_level = 0.1;
+    // NOTE: you need to set SFC_SET_COMPRESSION_LEVEL *BEFORE*
     // executing SFC_SET_BITRATE_MODE.
     if (SF_TRUE != sf_command(m_sndfile, SFC_SET_COMPRESSION_LEVEL,
                               &compression_level, sizeof(double))) {


### PR DESCRIPTION
Use libsndfile MP3 output capability to generate the MP3 file directly as the audio output.