### PR TITLE
Use C++20 as the required C++ compiler subset

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -16,9 +16,8 @@ The following Git repository is required:
 
 ## Platforms tested
 
-* Mac mini 2023 Apple Silicon (M2 Pro), macOS 14.4.1, Xcode 15.3 Command Line Tools
-* MacBook Air 13" Apple Silicon (M1) 2020, macOS 14.4.1, Xcode 15.3 Command Line Tools
-* Ubuntu 24.04 LTS x86\_64, gcc 13.2.0
+* Mac mini 2023 Apple Silicon (M2 Pro), macOS 14.7.1, Apple clang version 16.0.0 (clang-1600.0.26.4)
+* Ubuntu 24.04 LTS x86\_64, gcc 14.2.0
 * Raspberry Pi 4 with Raspberry Pi OS 64bit Lite (Debian Bookworm)
 
 ## Features under development

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -18,7 +18,7 @@ The following Git repository is required:
 
 * Mac mini 2023 Apple Silicon (M2 Pro), macOS 14.7.1, Apple clang version 16.0.0 (clang-1600.0.26.4)
 * Ubuntu 24.04 LTS x86\_64, gcc 14.2.0
-* Raspberry Pi 4 with Raspberry Pi OS 64bit Lite (Debian Bookworm)
+* Raspberry Pi 5 with Raspberry Pi OS 64bit Lite (Debian Bookworm)
 
 ## Features under development
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -219,7 +219,7 @@ set(OPTIMIZATION_FLAGS "-O3 -ftree-vectorize ")
 # Common compiler flags and options.
 #
 set(CMAKE_CXX_FLAGS
-    "-Wall -std=c++17 ${OPTIMIZATION_FLAGS} ${AIRSPY_INCLUDE_OPTION} ${AIRSPYHF_INCLUDE_OPTION} ${SNDFILE_INCLUDE_OPTION} ${EXTRA_FLAGS}"
+    "-Wall -std=c++20 ${OPTIMIZATION_FLAGS} ${AIRSPY_INCLUDE_OPTION} ${AIRSPYHF_INCLUDE_OPTION} ${SNDFILE_INCLUDE_OPTION} ${EXTRA_FLAGS}"
 )
 
 # For building airspy-fmradion sources

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -36,7 +36,7 @@ Keep the first line terse and short. Describe the details after the third line.
 
 ## C++ coding style
 
-airspy-fmradion is based on C++17. If you propose a modification of a different version of C++, nofity so explicitly in the pull request.
+airspy-fmradion is based on C++20. If you propose a modification of a different version of C++, nofity so explicitly in the pull request.
 
 The coding style is defined in the file `.clang-format`. To follow this style, do the following:
 

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ airspy-fmradion -m am -t airspyhf -q \
 ### airspy-fmradion requirements
 
 * Linux / macOS
-* C++17 (gcc, clang/llvm)
+* C++20 (gcc, clang/llvm)
 * [Airspy library](https://github.com/airspy/airspyone_host)
 * [Airspy HF library](https://github.com/airspy/airspyhf)
 * [RTL-SDR library](http://sdr.osmocom.org/trac/wiki/rtl-sdr)

--- a/doc/gpsdo-limitation-20240517.md
+++ b/doc/gpsdo-limitation-20240517.md
@@ -1,0 +1,7 @@
+# GPSDO clock limitation for AirSpy R2
+
+17-MAY-2024
+
+Giving 10MHz reference clock to AirSpy R2 from Leo Bodnar GPSDO
+did *not* give less noise on output; it gave spurious output
+~10kHz of -75dB, during no-sound signal of NHK-FM Tokyo 82.5MHz.

--- a/libairspyhf.md
+++ b/libairspyhf.md
@@ -8,6 +8,8 @@
 
 * R3.0.7 and R4.0.8 both work OK on libairspyhf 1.6.8.
 * For R4.0.8, use libairspy 1.8 to have full compatibility.
+* R5.0.0 on libairspyhf 1.6.8 is *not tested*.
+* For R5.0.0, use libairspy 1.8 to have full compatibility.
 
 ## For macOS Homebrew
 


### PR DESCRIPTION
* C++20 has been supported on macOS Clang, Ubuntu gcc, and Raspberry Pi OS gcc
* Including tested platform changes
* Other miscellaneous documentation addition