### PR TITLE
Use our own callback code for PortAudio output

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -17,7 +17,7 @@ The following Git repository is required:
 ## Platforms tested
 
 * Mac mini 2023 Apple Silicon (M2 Pro), macOS 15.6.1, Apple clang version 17.0.0 (clang-1700.0.13.5)
-* Ubuntu 24.04 LTS x86\_64, gcc 14.2.0
+* Ubuntu 24.04.3 LTS x86\_64, gcc 14.2.0
 * Raspberry Pi 5 with Raspberry Pi OS 64bit Lite (Debian Bookworm)
 
 ## Features under development
@@ -39,7 +39,11 @@ Intel Mac hardware is no longer supported by airspy-fmradion, although the autho
 
 ## Changes (including requirement changes)
 
-* xxx-0: changed PortAudioOutput to use the own callback code instead of the stock blocking stream. Minimal `pa_ringbuffer` library code was duplicated from PortAudio under PortAudio V19 License. Note the ringbuffer code is *not* a Git submodule.
+* xxx-0: Made the following changes:
+  * Changed PortAudioOutput to use the own callback code instead of the stock blocking stream, for shorter output latency. See 20230923 in this changelog.
+  * PortAudio minimum latency is no longer explicitly set, and is now set to defaultHighOutputLatency. Note: this behavior can be changed by setting compilation flag `PA_LOW_LATENCY` to defaultLowOutputLatency. Practically in many cases the low output latency setting works fine, but is not the default value, for safety.
+  * Minimal `pa_ringbuffer` library code for handling the PortAudio callback was duplicated and included from PortAudio under PortAudio V19 License. Note: the ringbuffer code is *not* a Git submodule.
+  * CMake minimum version is now 3.25.
 * 20250714-0: no major functionality changes from 20241208-0.
 * 20241208-0: [Use {fmt} as the output library.](https://github.com/jj1bdx/airspy-fmradion/pull/83)
   * {fmt} 11.0.2 or later is required.

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -16,7 +16,7 @@ The following Git repository is required:
 
 ## Platforms tested
 
-* Mac mini 2023 Apple Silicon (M2 Pro), macOS 15.5, Apple clang version 17.0.0 (clang-1700.0.13.5)
+* Mac mini 2023 Apple Silicon (M2 Pro), macOS 15.6.1, Apple clang version 17.0.0 (clang-1700.0.13.5)
 * Ubuntu 24.04 LTS x86\_64, gcc 14.2.0
 * Raspberry Pi 5 with Raspberry Pi OS 64bit Lite (Debian Bookworm)
 
@@ -39,6 +39,7 @@ Intel Mac hardware is no longer supported by airspy-fmradion, although the autho
 
 ## Changes (including requirement changes)
 
+* xxx-0: changed PortAudioOutput to use the own callback code instead of the stock blocking stream. Minimal `pa_ringbuffer` library code was duplicated from PortAudio under PortAudio V19 License. Note the ringbuffer code is *not* a Git submodule.
 * 20250714-0: no major functionality changes from 20241208-0.
 * 20241208-0: [Use {fmt} as the output library.](https://github.com/jj1bdx/airspy-fmradion/pull/83)
   * {fmt} 11.0.2 or later is required.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -292,6 +292,11 @@ set(sfmbase_HEADERS
     include/SoftFM.h
     include/Utility.h)
 
+# PortAudio pa_ringbuffer library
+
+add_library(pa_ringbuffer pa_ringbuffer/pa_ringbuffer.c)
+target_include_directories(pa_ringbuffer PUBLIC pa_ringbuffer)
+ 
 # cmake-format: off
 # For building r8brain-free-src
 # See https://github.com/baconpaul/SampleRateComparison for the details
@@ -319,6 +324,7 @@ add_executable(airspy-fmradion main.cpp)
 
 include_directories(
   ${CMAKE_SOURCE_DIR}/include
+  ${CMAKE_SOURCE_DIR}/pa_ringbuffer
   ${CMAKE_SOURCE_DIR}/r8brain-free-src
   ${AIRSPYHF_INCLUDE_DIRS}
   ${AIRSPY_INCLUDE_DIRS}
@@ -338,8 +344,13 @@ target_link_libraries(
   cmake_git_version_tracking)
 
 target_link_libraries(
-  sfmbase ${SNDFILE_LIBRARY} ${AIRSPY_LIBRARY} ${AIRSPYHF_LIBRARY}
-  ${RTLSDR_LIBRARY} ${LIBUSB_LIBRARY})
+  sfmbase
+  pa_ringbuffer
+  ${SNDFILE_LIBRARY}
+  ${AIRSPY_LIBRARY}
+  ${AIRSPYHF_LIBRARY}
+  ${RTLSDR_LIBRARY}
+  ${LIBUSB_LIBRARY})
 
 # Installation
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 # CMake definitions for airspy-fmradion
 
-cmake_minimum_required(VERSION 3.18)
+cmake_minimum_required(VERSION 3.25)
 project(airspy-fmradion)
 
 # Workaround for the compilation warning
@@ -20,15 +20,13 @@ FetchContent_Declare(
   GIT_TAG 6c0cb87edd029ddfb403a8e24577c144a03605a6)
 FetchContent_MakeAvailable(cmake_git_version_tracking)
 
-# EXPORT_COMPILE_COMMANDS is supported for CMake version 3.20 or later
-# only
-if(CMAKE_VERSION VERSION_LESS 3.20.0)
-  message(STATUS "No EXPORT_COMPILE_COMMANDS available")
-  message(STATUS "Use compdb for proper compile_commands.json handling")
-else()
-  set_target_properties(cmake_git_version_tracking
-                        PROPERTIES EXPORT_COMPILE_COMMANDS OFF)
-endif()
+# cmake-format: off
+# EXPORT_COMPILE_COMMANDS is supported for
+# CMake version 3.20 or later only
+# If necessary, use compdb for proper compile_commands.json handling
+# cmake-format: on
+set_target_properties(cmake_git_version_tracking
+                      PROPERTIES EXPORT_COMPILE_COMMANDS OFF)
 
 # Use pkg-config
 include(FindPkgConfig)

--- a/README.md
+++ b/README.md
@@ -113,6 +113,10 @@ brew install fmt
 
 * You need to install libfmt as described in [libfmt.md](libfmt.md).
 
+### pa\_ringbuffer
+
+Minimal code of PortAudio ring buffer `pa_ringbuffer`, included under the directory `pa_ringbuffer`, is built as a static library to link to the executable. This code is necessary for writing PortAudio callback code.
+
 ## Installation
 
 ```sh
@@ -122,6 +126,8 @@ git submodule update --init --recursive
 cmake -S . -B build
 cmake --build build --target all
 ```
+
+The executable built is located at `build/airspy-fmradion`.
 
 ## Basic command options
 

--- a/include/AudioOutput.h
+++ b/include/AudioOutput.h
@@ -123,6 +123,8 @@ public:
   // 131072 is for 65536/48000 ~= 1.3653 seconds
   // (Stereo playback needs *two* samples for a frame)
   static constexpr ring_buffer_size_t ringbuffer_length = 131072;
+  static constexpr ring_buffer_size_t ringbuffer_frame_size =
+      ringbuffer_length / 4;
 
   // Construct PortAudio output stream.
   //
@@ -148,6 +150,11 @@ private:
   // Terminate PortAudio
   // then add PortAudio error string to m_error and set m_zombie flag.
   void add_paerror(const std::string &msg);
+
+  inline static ring_buffer_size_t rbs_min(ring_buffer_size_t a,
+                                           ring_buffer_size_t b) {
+    return (a < b) ? a : b;
+  }
 
   unsigned int m_nchannels;
   PaStreamParameters m_outputparams;

--- a/include/AudioOutput.h
+++ b/include/AudioOutput.h
@@ -112,6 +112,8 @@ public:
   // 65536 frames for 48000 frames/sec ~= 2.73 seconds
   // (Stereo playback needs *two* samples for a frame)
   static constexpr ring_buffer_size_t ringbuffer_frame_length = 65536;
+  // This value should be large to prevent unwanted noise
+  static constexpr unsigned long frames_per_buffer = 2048;
 
   // Construct PortAudio output stream.
   //
@@ -143,6 +145,11 @@ private:
         static_cast<PortAudioOutput *>(user_data);
     return portaudio_object->stream_callback(static_cast<float *>(output),
                                              frame_count);
+  }
+
+  static ring_buffer_size_t rbs_min(ring_buffer_size_t a,
+                                    ring_buffer_size_t b) {
+    return (a < b) ? a : b;
   }
 
   unsigned int m_nchannels;

--- a/include/AudioOutput.h
+++ b/include/AudioOutput.h
@@ -107,19 +107,11 @@ class PortAudioOutput : public AudioOutput {
 public:
   // Static variables.
 
-  // Minimum latency for audio output in seconds
-  // Note:
-  // on macOS, less than 0.1sec won't work
-
-  static constexpr PaTime minimum_latency = 0.1;
-
   // Ring buffer size
   // *must be* a power of 2
   // 262144 is for 131072/48000 ~= 2.73 seconds
   // (Stereo playback needs *two* samples for a frame)
   static constexpr ring_buffer_size_t ringbuffer_length = 262144;
-  static constexpr ring_buffer_size_t ringbuffer_frame_size =
-      ringbuffer_length / 4;
 
   // Construct PortAudio output stream.
   //
@@ -140,11 +132,6 @@ private:
   // Terminate PortAudio
   // then add PortAudio error string to m_error and set m_zombie flag.
   void add_paerror(const std::string &msg);
-
-  inline static ring_buffer_size_t rbs_min(ring_buffer_size_t a,
-                                           ring_buffer_size_t b) {
-    return (a < b) ? a : b;
-  }
 
   // Static C-style callback function for PortAudio stream.
   // user_data has the pointer to the PortAudio object itself ('this').

--- a/include/AudioOutput.h
+++ b/include/AudioOutput.h
@@ -27,6 +27,10 @@
 #include "portaudio.h"
 #include <sndfile.h>
 
+extern "C" {
+#include "pa_ringbuffer.h"
+}
+
 /** Base class for writing audio data to file or playback. */
 class AudioOutput {
 public:
@@ -113,7 +117,13 @@ public:
 
   static constexpr PaTime minimum_latency = 0.04;
 
-  //
+  // Ring buffer size
+  // *must be* a power of 2
+  // 65536 looks practical, but maybe should extend to 131072
+  // 131072 is for 65536/48000 ~= 1.3653 seconds
+  // (Stereo playback needs *two* samples for a frame)
+  static constexpr ring_buffer_size_t ringbuffer_length = 131072;
+
   // Construct PortAudio output stream.
   //
   // device_index :: device index number
@@ -136,6 +146,8 @@ private:
   PaStream *m_stream;
   PaError m_paerror;
   volk::vector<float> m_floatbuf;
+  PaUtilRingBuffer m_ringbuffer;
+  volk::vector<float> m_ringbuffer_data;
 };
 
 #endif

--- a/include/AudioOutput.h
+++ b/include/AudioOutput.h
@@ -109,9 +109,9 @@ public:
 
   // Ring buffer size
   // *must be* a power of 2
-  // 262144 is for 131072/48000 ~= 2.73 seconds
+  // 65536 frames for 48000 frames/sec ~= 2.73 seconds
   // (Stereo playback needs *two* samples for a frame)
-  static constexpr ring_buffer_size_t ringbuffer_length = 262144;
+  static constexpr ring_buffer_size_t ringbuffer_frame_length = 65536;
 
   // Construct PortAudio output stream.
   //

--- a/include/AudioOutput.h
+++ b/include/AudioOutput.h
@@ -136,6 +136,14 @@ public:
   virtual bool write(const SampleVector &samples) override;
   virtual void output_close() override;
 
+  // Static C-style callback function for PortAudio.
+  int pa_callback(const void *input, void *output, unsigned long frame_count,
+                  const PaStreamCallbackTimeInfo *time_info,
+                  PaStreamCallbackFlags status_flags, void *user_data);
+
+  // C++ callback code called from pa_callback().
+  int stream_callback(float *output, unsigned long frame_count);
+
 private:
   // Terminate PortAudio
   // then add PortAudio error string to m_error and set m_zombie flag.

--- a/include/AudioOutput.h
+++ b/include/AudioOutput.h
@@ -138,11 +138,6 @@ public:
   virtual bool write(const SampleVector &samples) override;
   virtual void output_close() override;
 
-  // Static C-style callback function for PortAudio.
-  int pa_callback(const void *input, void *output, unsigned long frame_count,
-                  const PaStreamCallbackTimeInfo *time_info,
-                  PaStreamCallbackFlags status_flags, void *user_data);
-
   // C++ callback code called from pa_callback().
   int stream_callback(float *output, unsigned long frame_count);
 
@@ -154,6 +149,18 @@ private:
   inline static ring_buffer_size_t rbs_min(ring_buffer_size_t a,
                                            ring_buffer_size_t b) {
     return (a < b) ? a : b;
+  }
+
+  // Static C-style callback function for PortAudio stream.
+  // user_data has the pointer to the PortAudio object itself ('this').
+  static int pa_callback(const void *input, void *output,
+                         unsigned long frame_count,
+                         const PaStreamCallbackTimeInfo *time_info,
+                         PaStreamCallbackFlags status_flags, void *user_data) {
+    PortAudioOutput *portaudio_object =
+        static_cast<PortAudioOutput *>(user_data);
+    return portaudio_object->stream_callback(static_cast<float *>(output),
+                                             frame_count);
   }
 
   unsigned int m_nchannels;

--- a/include/AudioOutput.h
+++ b/include/AudioOutput.h
@@ -109,7 +109,7 @@ public:
 
   // Ring buffer size
   // *must be* a power of 2
-  // 65536 frames for 48000 frames/sec ~= 2.73 seconds
+  // 65536 frames for 48000 frames/sec ~= 1.365 seconds
   // (Stereo playback needs *two* samples for a frame)
   static constexpr ring_buffer_size_t ringbuffer_frame_length = 65536;
 
@@ -124,9 +124,6 @@ public:
   virtual ~PortAudioOutput() override;
   virtual bool write(const SampleVector &samples) override;
   virtual void output_close() override;
-
-  // C++ callback code called from pa_callback().
-  int stream_callback(float *output, unsigned long frame_count);
 
 private:
   // Terminate PortAudio
@@ -145,8 +142,11 @@ private:
                                              frame_count);
   }
 
-  static ring_buffer_size_t rbs_min(ring_buffer_size_t a,
-                                    ring_buffer_size_t b) {
+  // C++ callback code called from pa_callback().
+  int stream_callback(float *output, unsigned long frame_count);
+
+  inline static ring_buffer_size_t rbs_min(ring_buffer_size_t a,
+                                           ring_buffer_size_t b) {
     return (a < b) ? a : b;
   }
 

--- a/include/AudioOutput.h
+++ b/include/AudioOutput.h
@@ -108,21 +108,16 @@ public:
   // Static variables.
 
   // Minimum latency for audio output in seconds
+  // Note:
+  // on macOS, less than 0.1sec won't work
 
-  // Values of m_outputparams.suggestedLatency from PortAudio:
-  // Mac mini 2023 with macOS 14.3.1: 0.014717
-  // Ubuntu 22.04.4 on x86_64: 0.034830
-  // Kenji's experiments show that
-  // 40ms (0.04) is sufficient for macOS, Ubuntu, and Raspberry Pi OS
-
-  static constexpr PaTime minimum_latency = 0.04;
+  static constexpr PaTime minimum_latency = 0.1;
 
   // Ring buffer size
   // *must be* a power of 2
-  // 65536 looks practical, but maybe should extend to 131072
-  // 131072 is for 65536/48000 ~= 1.3653 seconds
+  // 262144 is for 131072/48000 ~= 2.73 seconds
   // (Stereo playback needs *two* samples for a frame)
-  static constexpr ring_buffer_size_t ringbuffer_length = 131072;
+  static constexpr ring_buffer_size_t ringbuffer_length = 262144;
   static constexpr ring_buffer_size_t ringbuffer_frame_size =
       ringbuffer_length / 4;
 

--- a/include/AudioOutput.h
+++ b/include/AudioOutput.h
@@ -112,8 +112,6 @@ public:
   // 65536 frames for 48000 frames/sec ~= 2.73 seconds
   // (Stereo playback needs *two* samples for a frame)
   static constexpr ring_buffer_size_t ringbuffer_frame_length = 65536;
-  // This value should be large to prevent unwanted noise
-  static constexpr unsigned long frames_per_buffer = 2048;
 
   // Construct PortAudio output stream.
   //

--- a/pa_ringbuffer/README.md
+++ b/pa_ringbuffer/README.md
@@ -1,0 +1,8 @@
+# pa_ringbuffer
+
+Code in this directory is duplicated from [PortAudio](https://github.com/PortAudio/portaudio), under [PortAudio V19 License](https://www.portaudio.com/license.html).
+
+The original directory of the code is located at `src/common`. 
+
+The files here are for building the Ring Buffer utility only. 
+

--- a/pa_ringbuffer/README.md
+++ b/pa_ringbuffer/README.md
@@ -2,9 +2,9 @@
 
 Code in this directory is duplicated from [PortAudio](https://github.com/PortAudio/portaudio), under [PortAudio V19 License](https://www.portaudio.com/license.html).
 
-The original directory of the code is located at `src/common`. 
+The original directory of the code is located at `src/common` in the PortAudio repository. The files included here are for building the Ring Buffer utility only.
 
-The files here are for building the Ring Buffer utility only. 
+While building airspy-fmradion, a static library solely containing pa_ringbuffer.c is built and linked the code to the executable.
 
 ## Last commit message headers in PortAudio
 
@@ -28,5 +28,5 @@ commit b94c49ee21a24a12d4fb35f184f89b5ee24cc494
 Author: Phil Burk <philburk@mobileer.com>
 Date:   Wed Dec 1 18:25:04 2021 -0700
 ```
-  
+
 [End of document]

--- a/pa_ringbuffer/README.md
+++ b/pa_ringbuffer/README.md
@@ -6,3 +6,27 @@ The original directory of the code is located at `src/common`.
 
 The files here are for building the Ring Buffer utility only. 
 
+## Last commit message headers in PortAudio
+
+```
+% git log pa_ringbuffer.c
+commit fac71001ee55c62c71801979eb3216b92b009988
+Author: Ross Bencina <rossb@audiomulch.com>
+Date:   Thu Jan 21 23:06:08 2021 +1100
+```
+
+```
+% git log pa_ringbuffer.h
+commit fac71001ee55c62c71801979eb3216b92b009988
+Author: Ross Bencina <rossb@audiomulch.com>
+Date:   Thu Jan 21 23:06:08 2021 +1100
+```
+
+```
+% git log pa_memorybarrier.h
+commit b94c49ee21a24a12d4fb35f184f89b5ee24cc494
+Author: Phil Burk <philburk@mobileer.com>
+Date:   Wed Dec 1 18:25:04 2021 -0700
+```
+  
+[End of document]

--- a/pa_ringbuffer/pa_memorybarrier.h
+++ b/pa_ringbuffer/pa_memorybarrier.h
@@ -1,0 +1,138 @@
+/*
+ * $Id: pa_memorybarrier.h 1240 2007-07-17 13:05:07Z bjornroche $
+ * Portable Audio I/O Library
+ * Memory barrier utilities
+ *
+ * Author: Bjorn Roche, XO Audio, LLC
+ *
+ * This program uses the PortAudio Portable Audio Library.
+ * For more information see: http://www.portaudio.com
+ * Copyright (c) 1999-2000 Ross Bencina and Phil Burk
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining
+ * a copy of this software and associated documentation files
+ * (the "Software"), to deal in the Software without restriction,
+ * including without limitation the rights to use, copy, modify, merge,
+ * publish, distribute, sublicense, and/or sell copies of the Software,
+ * and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ * IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR
+ * ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF
+ * CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+/*
+ * The text above constitutes the entire PortAudio license; however,
+ * the PortAudio community also makes the following non-binding requests:
+ *
+ * Any person wishing to distribute modifications to the Software is
+ * requested to send the modifications to the original developer so that
+ * they can be incorporated into the canonical version. It is also
+ * requested that these non-binding requests be included along with the
+ * license above.
+ */
+
+/**
+ @file pa_memorybarrier.h
+ @ingroup common_src
+*/
+
+/****************
+ * Some memory barrier primitives based on the system.
+ * right now only OS X, FreeBSD, and Linux are supported. In addition to providing
+ * memory barriers, these functions should ensure that data cached in registers
+ * is written out to cache where it can be snooped by other CPUs. (ie, the volatile
+ * keyword should not be required)
+ *
+ * the primitives that must be defined are:
+ *
+ * PaUtil_FullMemoryBarrier()
+ * PaUtil_ReadMemoryBarrier()
+ * PaUtil_WriteMemoryBarrier()
+ *
+ ****************/
+
+#if defined(__APPLE__)
+/* Support for the atomic library was added in C11.
+ */
+#   if (__STDC_VERSION__ < 201112L) || defined(__STDC_NO_ATOMICS__)
+#       include <libkern/OSAtomic.h>
+        /* Here are the memory barrier functions. Mac OS X only provides
+           full memory barriers, so the three types of barriers are the same,
+           however, these barriers are superior to compiler-based ones.
+           These were deprecated in MacOS 10.12. */
+#       define PaUtil_FullMemoryBarrier()  OSMemoryBarrier()
+#       define PaUtil_ReadMemoryBarrier()  OSMemoryBarrier()
+#       define PaUtil_WriteMemoryBarrier() OSMemoryBarrier()
+#   else
+#       include <stdatomic.h>
+#       define PaUtil_FullMemoryBarrier()  atomic_thread_fence(memory_order_seq_cst)
+#       define PaUtil_ReadMemoryBarrier()  atomic_thread_fence(memory_order_acquire)
+#       define PaUtil_WriteMemoryBarrier() atomic_thread_fence(memory_order_release)
+#   endif
+#elif defined(__GNUC__)
+    /* GCC >= 4.1 has built-in intrinsics. We'll use those */
+#   if (__GNUC__ > 4) || (__GNUC__ == 4 && __GNUC_MINOR__ >= 1)
+#       define PaUtil_FullMemoryBarrier()  __sync_synchronize()
+#       define PaUtil_ReadMemoryBarrier()  __sync_synchronize()
+#       define PaUtil_WriteMemoryBarrier() __sync_synchronize()
+    /* as a fallback, GCC understands volatile asm and "memory" to mean it
+     * should not reorder memory read/writes */
+    /* Note that it is not clear that any compiler actually defines __PPC__,
+     * it can probably removed safely. */
+#   elif defined( __ppc__ ) || defined( __powerpc__) || defined( __PPC__ )
+#       define PaUtil_FullMemoryBarrier()  asm volatile("sync":::"memory")
+#       define PaUtil_ReadMemoryBarrier()  asm volatile("sync":::"memory")
+#       define PaUtil_WriteMemoryBarrier() asm volatile("sync":::"memory")
+#   elif defined( __i386__ ) || defined( __i486__ ) || defined( __i586__ ) || \
+            defined( __i686__ ) || defined( __x86_64__ )
+#       define PaUtil_FullMemoryBarrier()  asm volatile("mfence":::"memory")
+#       define PaUtil_ReadMemoryBarrier()  asm volatile("lfence":::"memory")
+#       define PaUtil_WriteMemoryBarrier() asm volatile("sfence":::"memory")
+#   else
+#       ifdef ALLOW_SMP_DANGERS
+#           warning Memory barriers not defined on this system or system unknown
+#           warning For SMP safety, you should fix this.
+#           define PaUtil_FullMemoryBarrier()
+#           define PaUtil_ReadMemoryBarrier()
+#           define PaUtil_WriteMemoryBarrier()
+#       else
+#           error Memory barriers are not defined on this system. You can still compile by defining ALLOW_SMP_DANGERS, but SMP safety will not be guaranteed.
+#       endif
+#   endif
+#elif (_MSC_VER >= 1400) && !defined(_WIN32_WCE)
+#   include <intrin.h>
+#   pragma intrinsic(_ReadWriteBarrier)
+#   pragma intrinsic(_ReadBarrier)
+#   pragma intrinsic(_WriteBarrier)
+/* note that MSVC intrinsics _ReadWriteBarrier(), _ReadBarrier(), _WriteBarrier() are just compiler barriers *not* memory barriers */
+#   define PaUtil_FullMemoryBarrier()  _ReadWriteBarrier()
+#   define PaUtil_ReadMemoryBarrier()  _ReadBarrier()
+#   define PaUtil_WriteMemoryBarrier() _WriteBarrier()
+#elif defined(_WIN32_WCE)
+#   define PaUtil_FullMemoryBarrier()
+#   define PaUtil_ReadMemoryBarrier()
+#   define PaUtil_WriteMemoryBarrier()
+#elif defined(_MSC_VER) || defined(__BORLANDC__)
+#   define PaUtil_FullMemoryBarrier()  _asm { lock add    [esp], 0 }
+#   define PaUtil_ReadMemoryBarrier()  _asm { lock add    [esp], 0 }
+#   define PaUtil_WriteMemoryBarrier() _asm { lock add    [esp], 0 }
+#else
+#   ifdef ALLOW_SMP_DANGERS
+#       warning Memory barriers not defined on this system or system unknown
+#       warning For SMP safety, you should fix this.
+#       define PaUtil_FullMemoryBarrier()
+#       define PaUtil_ReadMemoryBarrier()
+#       define PaUtil_WriteMemoryBarrier()
+#   else
+#       error Memory barriers are not defined on this system. You can still compile by defining ALLOW_SMP_DANGERS, but SMP safety will not be guaranteed.
+#   endif
+#endif

--- a/pa_ringbuffer/pa_ringbuffer.c
+++ b/pa_ringbuffer/pa_ringbuffer.c
@@ -1,0 +1,237 @@
+/*
+ * $Id$
+ * Portable Audio I/O Library
+ * Ring Buffer utility.
+ *
+ * Author: Phil Burk, http://www.softsynth.com
+ * modified for SMP safety on Mac OS X by Bjorn Roche
+ * modified for SMP safety on Linux by Leland Lucius
+ * also, allowed for const where possible
+ * modified for multiple-byte-sized data elements by Sven Fischer
+ *
+ * Note that this is safe only for a single-thread reader and a
+ * single-thread writer.
+ *
+ * This program uses the PortAudio Portable Audio Library.
+ * For more information see: http://www.portaudio.com
+ * Copyright (c) 1999-2000 Ross Bencina and Phil Burk
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining
+ * a copy of this software and associated documentation files
+ * (the "Software"), to deal in the Software without restriction,
+ * including without limitation the rights to use, copy, modify, merge,
+ * publish, distribute, sublicense, and/or sell copies of the Software,
+ * and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ * IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR
+ * ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF
+ * CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+/*
+ * The text above constitutes the entire PortAudio license; however,
+ * the PortAudio community also makes the following non-binding requests:
+ *
+ * Any person wishing to distribute modifications to the Software is
+ * requested to send the modifications to the original developer so that
+ * they can be incorporated into the canonical version. It is also
+ * requested that these non-binding requests be included along with the
+ * license above.
+ */
+
+/**
+ @file
+ @ingroup common_src
+*/
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <math.h>
+#include "pa_ringbuffer.h"
+#include <string.h>
+#include "pa_memorybarrier.h"
+
+/***************************************************************************
+ * Initialize FIFO.
+ * elementCount must be power of 2, returns -1 if not.
+ */
+ring_buffer_size_t PaUtil_InitializeRingBuffer( PaUtilRingBuffer *rbuf, ring_buffer_size_t elementSizeBytes, ring_buffer_size_t elementCount, void *dataPtr )
+{
+    if( ((elementCount-1) & elementCount) != 0) return -1; /* Not Power of two. */
+    rbuf->bufferSize = elementCount;
+    rbuf->buffer = (char *)dataPtr;
+    PaUtil_FlushRingBuffer( rbuf );
+    rbuf->bigMask = (elementCount*2)-1;
+    rbuf->smallMask = (elementCount)-1;
+    rbuf->elementSizeBytes = elementSizeBytes;
+    return 0;
+}
+
+/***************************************************************************
+** Return number of elements available for reading. */
+ring_buffer_size_t PaUtil_GetRingBufferReadAvailable( const PaUtilRingBuffer *rbuf )
+{
+    return ( (rbuf->writeIndex - rbuf->readIndex) & rbuf->bigMask );
+}
+/***************************************************************************
+** Return number of elements available for writing. */
+ring_buffer_size_t PaUtil_GetRingBufferWriteAvailable( const PaUtilRingBuffer *rbuf )
+{
+    return ( rbuf->bufferSize - PaUtil_GetRingBufferReadAvailable(rbuf));
+}
+
+/***************************************************************************
+** Clear buffer. Should only be called when buffer is NOT being read or written. */
+void PaUtil_FlushRingBuffer( PaUtilRingBuffer *rbuf )
+{
+    rbuf->writeIndex = rbuf->readIndex = 0;
+}
+
+/***************************************************************************
+** Get address of region(s) to which we can write data.
+** If the region is contiguous, size2 will be zero.
+** If non-contiguous, size2 will be the size of second region.
+** Returns room available to be written or elementCount, whichever is smaller.
+*/
+ring_buffer_size_t PaUtil_GetRingBufferWriteRegions( PaUtilRingBuffer *rbuf, ring_buffer_size_t elementCount,
+                                       void **dataPtr1, ring_buffer_size_t *sizePtr1,
+                                       void **dataPtr2, ring_buffer_size_t *sizePtr2 )
+{
+    ring_buffer_size_t   index;
+    ring_buffer_size_t   available = PaUtil_GetRingBufferWriteAvailable( rbuf );
+    if( elementCount > available ) elementCount = available;
+    /* Check to see if write is not contiguous. */
+    index = rbuf->writeIndex & rbuf->smallMask;
+    if( (index + elementCount) > rbuf->bufferSize )
+    {
+        /* Write data in two blocks that wrap the buffer. */
+        ring_buffer_size_t   firstHalf = rbuf->bufferSize - index;
+        *dataPtr1 = &rbuf->buffer[index*rbuf->elementSizeBytes];
+        *sizePtr1 = firstHalf;
+        *dataPtr2 = &rbuf->buffer[0];
+        *sizePtr2 = elementCount - firstHalf;
+    }
+    else
+    {
+        *dataPtr1 = &rbuf->buffer[index*rbuf->elementSizeBytes];
+        *sizePtr1 = elementCount;
+        *dataPtr2 = NULL;
+        *sizePtr2 = 0;
+    }
+
+    if( available )
+        PaUtil_FullMemoryBarrier(); /* (write-after-read) => full barrier */
+
+    return elementCount;
+}
+
+
+/***************************************************************************
+*/
+ring_buffer_size_t PaUtil_AdvanceRingBufferWriteIndex( PaUtilRingBuffer *rbuf, ring_buffer_size_t elementCount )
+{
+    /* ensure that previous writes are seen before we update the write index
+       (write after write)
+    */
+    PaUtil_WriteMemoryBarrier();
+    return rbuf->writeIndex = (rbuf->writeIndex + elementCount) & rbuf->bigMask;
+}
+
+/***************************************************************************
+** Get address of region(s) from which we can read data.
+** If the region is contiguous, size2 will be zero.
+** If non-contiguous, size2 will be the size of second region.
+** Returns room available to be read or elementCount, whichever is smaller.
+*/
+ring_buffer_size_t PaUtil_GetRingBufferReadRegions( PaUtilRingBuffer *rbuf, ring_buffer_size_t elementCount,
+                                void **dataPtr1, ring_buffer_size_t *sizePtr1,
+                                void **dataPtr2, ring_buffer_size_t *sizePtr2 )
+{
+    ring_buffer_size_t   index;
+    ring_buffer_size_t   available = PaUtil_GetRingBufferReadAvailable( rbuf ); /* doesn't use memory barrier */
+    if( elementCount > available ) elementCount = available;
+    /* Check to see if read is not contiguous. */
+    index = rbuf->readIndex & rbuf->smallMask;
+    if( (index + elementCount) > rbuf->bufferSize )
+    {
+        /* Write data in two blocks that wrap the buffer. */
+        ring_buffer_size_t firstHalf = rbuf->bufferSize - index;
+        *dataPtr1 = &rbuf->buffer[index*rbuf->elementSizeBytes];
+        *sizePtr1 = firstHalf;
+        *dataPtr2 = &rbuf->buffer[0];
+        *sizePtr2 = elementCount - firstHalf;
+    }
+    else
+    {
+        *dataPtr1 = &rbuf->buffer[index*rbuf->elementSizeBytes];
+        *sizePtr1 = elementCount;
+        *dataPtr2 = NULL;
+        *sizePtr2 = 0;
+    }
+
+    if( available )
+        PaUtil_ReadMemoryBarrier(); /* (read-after-read) => read barrier */
+
+    return elementCount;
+}
+/***************************************************************************
+*/
+ring_buffer_size_t PaUtil_AdvanceRingBufferReadIndex( PaUtilRingBuffer *rbuf, ring_buffer_size_t elementCount )
+{
+    /* ensure that previous reads (copies out of the ring buffer) are always completed before updating (writing) the read index.
+       (write-after-read) => full barrier
+    */
+    PaUtil_FullMemoryBarrier();
+    return rbuf->readIndex = (rbuf->readIndex + elementCount) & rbuf->bigMask;
+}
+
+/***************************************************************************
+** Return elements written. */
+ring_buffer_size_t PaUtil_WriteRingBuffer( PaUtilRingBuffer *rbuf, const void *data, ring_buffer_size_t elementCount )
+{
+    ring_buffer_size_t size1, size2, numWritten;
+    void *data1, *data2;
+    numWritten = PaUtil_GetRingBufferWriteRegions( rbuf, elementCount, &data1, &size1, &data2, &size2 );
+    if( size2 > 0 )
+    {
+
+        memcpy( data1, data, size1*rbuf->elementSizeBytes );
+        data = ((char *)data) + size1*rbuf->elementSizeBytes;
+        memcpy( data2, data, size2*rbuf->elementSizeBytes );
+    }
+    else
+    {
+        memcpy( data1, data, size1*rbuf->elementSizeBytes );
+    }
+    PaUtil_AdvanceRingBufferWriteIndex( rbuf, numWritten );
+    return numWritten;
+}
+
+/***************************************************************************
+** Return elements read. */
+ring_buffer_size_t PaUtil_ReadRingBuffer( PaUtilRingBuffer *rbuf, void *data, ring_buffer_size_t elementCount )
+{
+    ring_buffer_size_t size1, size2, numRead;
+    void *data1, *data2;
+    numRead = PaUtil_GetRingBufferReadRegions( rbuf, elementCount, &data1, &size1, &data2, &size2 );
+    if( size2 > 0 )
+    {
+        memcpy( data, data1, size1*rbuf->elementSizeBytes );
+        data = ((char *)data) + size1*rbuf->elementSizeBytes;
+        memcpy( data, data2, size2*rbuf->elementSizeBytes );
+    }
+    else
+    {
+        memcpy( data, data1, size1*rbuf->elementSizeBytes );
+    }
+    PaUtil_AdvanceRingBufferReadIndex( rbuf, numRead );
+    return numRead;
+}

--- a/pa_ringbuffer/pa_ringbuffer.h
+++ b/pa_ringbuffer/pa_ringbuffer.h
@@ -1,0 +1,236 @@
+#ifndef PA_RINGBUFFER_H
+#define PA_RINGBUFFER_H
+/*
+ * $Id$
+ * Portable Audio I/O Library
+ * Ring Buffer utility.
+ *
+ * Author: Phil Burk, http://www.softsynth.com
+ * modified for SMP safety on OS X by Bjorn Roche.
+ * also allowed for const where possible.
+ * modified for multiple-byte-sized data elements by Sven Fischer
+ *
+ * Note that this is safe only for a single-thread reader
+ * and a single-thread writer.
+ *
+ * This program is distributed with the PortAudio Portable Audio Library.
+ * For more information see: http://www.portaudio.com
+ * Copyright (c) 1999-2000 Ross Bencina and Phil Burk
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining
+ * a copy of this software and associated documentation files
+ * (the "Software"), to deal in the Software without restriction,
+ * including without limitation the rights to use, copy, modify, merge,
+ * publish, distribute, sublicense, and/or sell copies of the Software,
+ * and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ * IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR
+ * ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF
+ * CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+/*
+ * The text above constitutes the entire PortAudio license; however,
+ * the PortAudio community also makes the following non-binding requests:
+ *
+ * Any person wishing to distribute modifications to the Software is
+ * requested to send the modifications to the original developer so that
+ * they can be incorporated into the canonical version. It is also
+ * requested that these non-binding requests be included along with the
+ * license above.
+ */
+
+/** @file
+ @ingroup common_src
+ @brief Single-reader single-writer lock-free ring buffer
+
+ PaUtilRingBuffer is a ring buffer used to transport samples between
+ different execution contexts (threads, OS callbacks, interrupt handlers)
+ without requiring the use of any locks. This only works when there is
+ a single reader and a single writer (ie. one thread or callback writes
+ to the ring buffer, another thread or callback reads from it).
+
+ The PaUtilRingBuffer structure manages a ring buffer containing N
+ elements, where N must be a power of two. An element may be any size
+ (specified in bytes).
+
+ The memory area used to store the buffer elements must be allocated by
+ the client prior to calling PaUtil_InitializeRingBuffer() and must outlive
+ the use of the ring buffer.
+
+ @note The ring buffer functions are not normally exposed in the PortAudio libraries.
+ If you want to call them then you will need to add pa_ringbuffer.c to your application source code.
+*/
+
+#if defined(__APPLE__)
+#include <sys/types.h>
+typedef int32_t ring_buffer_size_t;
+#elif defined( __GNUC__ )
+typedef long ring_buffer_size_t;
+#elif (_MSC_VER >= 1400)
+typedef long ring_buffer_size_t;
+#elif defined(_MSC_VER) || defined(__BORLANDC__)
+typedef long ring_buffer_size_t;
+#else
+typedef long ring_buffer_size_t;
+#endif
+
+
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif /* __cplusplus */
+
+typedef struct PaUtilRingBuffer
+{
+    ring_buffer_size_t  bufferSize; /**< Number of elements in FIFO. Power of 2. Set by PaUtil_InitRingBuffer. */
+    volatile ring_buffer_size_t  writeIndex; /**< Index of next writable element. Set by PaUtil_AdvanceRingBufferWriteIndex. */
+    volatile ring_buffer_size_t  readIndex;  /**< Index of next readable element. Set by PaUtil_AdvanceRingBufferReadIndex. */
+    ring_buffer_size_t  bigMask;    /**< Used for wrapping indices with extra bit to distinguish full/empty. */
+    ring_buffer_size_t  smallMask;  /**< Used for fitting indices to buffer. */
+    ring_buffer_size_t  elementSizeBytes; /**< Number of bytes per element. */
+    char  *buffer;    /**< Pointer to the buffer containing the actual data. */
+}PaUtilRingBuffer;
+
+/** Initialize Ring Buffer to empty state ready to have elements written to it.
+
+ @param rbuf The ring buffer.
+
+ @param elementSizeBytes The size of a single data element in bytes.
+
+ @param elementCount The number of elements in the buffer (must be a power of 2).
+
+ @param dataPtr A pointer to a previously allocated area where the data
+ will be maintained.  It must be elementCount*elementSizeBytes long.
+
+ @return -1 if elementCount is not a power of 2, otherwise 0.
+*/
+ring_buffer_size_t PaUtil_InitializeRingBuffer( PaUtilRingBuffer *rbuf, ring_buffer_size_t elementSizeBytes, ring_buffer_size_t elementCount, void *dataPtr );
+
+/** Reset buffer to empty. Should only be called when buffer is NOT being read or written.
+
+ @param rbuf The ring buffer.
+*/
+void PaUtil_FlushRingBuffer( PaUtilRingBuffer *rbuf );
+
+/** Retrieve the number of elements available in the ring buffer for writing.
+
+ @param rbuf The ring buffer.
+
+ @return The number of elements available for writing.
+*/
+ring_buffer_size_t PaUtil_GetRingBufferWriteAvailable( const PaUtilRingBuffer *rbuf );
+
+/** Retrieve the number of elements available in the ring buffer for reading.
+
+ @param rbuf The ring buffer.
+
+ @return The number of elements available for reading.
+*/
+ring_buffer_size_t PaUtil_GetRingBufferReadAvailable( const PaUtilRingBuffer *rbuf );
+
+/** Write data to the ring buffer.
+
+ @param rbuf The ring buffer.
+
+ @param data The address of new data to write to the buffer.
+
+ @param elementCount The number of elements to be written.
+
+ @return The number of elements written.
+*/
+ring_buffer_size_t PaUtil_WriteRingBuffer( PaUtilRingBuffer *rbuf, const void *data, ring_buffer_size_t elementCount );
+
+/** Read data from the ring buffer.
+
+ @param rbuf The ring buffer.
+
+ @param data The address where the data should be stored.
+
+ @param elementCount The number of elements to be read.
+
+ @return The number of elements read.
+*/
+ring_buffer_size_t PaUtil_ReadRingBuffer( PaUtilRingBuffer *rbuf, void *data, ring_buffer_size_t elementCount );
+
+/** Get address of region(s) to which we can write data.
+
+ @param rbuf The ring buffer.
+
+ @param elementCount The number of elements desired.
+
+ @param dataPtr1 The address where the first (or only) region pointer will be
+ stored.
+
+ @param sizePtr1 The address where the first (or only) region length will be
+ stored.
+
+ @param dataPtr2 The address where the second region pointer will be stored if
+ the first region is too small to satisfy elementCount.
+
+ @param sizePtr2 The address where the second region length will be stored if
+ the first region is too small to satisfy elementCount.
+
+ @return The room available to be written or elementCount, whichever is smaller.
+*/
+ring_buffer_size_t PaUtil_GetRingBufferWriteRegions( PaUtilRingBuffer *rbuf, ring_buffer_size_t elementCount,
+                                       void **dataPtr1, ring_buffer_size_t *sizePtr1,
+                                       void **dataPtr2, ring_buffer_size_t *sizePtr2 );
+
+/** Advance the write index to the next location to be written.
+
+ @param rbuf The ring buffer.
+
+ @param elementCount The number of elements to advance.
+
+ @return The new position.
+*/
+ring_buffer_size_t PaUtil_AdvanceRingBufferWriteIndex( PaUtilRingBuffer *rbuf, ring_buffer_size_t elementCount );
+
+/** Get address of region(s) from which we can read data.
+
+ @param rbuf The ring buffer.
+
+ @param elementCount The number of elements desired.
+
+ @param dataPtr1 The address where the first (or only) region pointer will be
+ stored.
+
+ @param sizePtr1 The address where the first (or only) region length will be
+ stored.
+
+ @param dataPtr2 The address where the second region pointer will be stored if
+ the first region is too small to satisfy elementCount.
+
+ @param sizePtr2 The address where the second region length will be stored if
+ the first region is too small to satisfy elementCount.
+
+ @return The number of elements available for reading.
+*/
+ring_buffer_size_t PaUtil_GetRingBufferReadRegions( PaUtilRingBuffer *rbuf, ring_buffer_size_t elementCount,
+                                      void **dataPtr1, ring_buffer_size_t *sizePtr1,
+                                      void **dataPtr2, ring_buffer_size_t *sizePtr2 );
+
+/** Advance the read index to the next location to be read.
+
+ @param rbuf The ring buffer.
+
+ @param elementCount The number of elements to advance.
+
+ @return The new position.
+*/
+ring_buffer_size_t PaUtil_AdvanceRingBufferReadIndex( PaUtilRingBuffer *rbuf, ring_buffer_size_t elementCount );
+
+#ifdef __cplusplus
+}
+#endif /* __cplusplus */
+#endif /* PA_RINGBUFFER_H */

--- a/sfmbase/AudioOutput.cpp
+++ b/sfmbase/AudioOutput.cpp
@@ -270,7 +270,7 @@ int PortAudioOutput::stream_callback(float *output, unsigned long frame_count) {
   ring_buffer_size_t frames_to_send;
   ring_buffer_size_t available =
       PaUtil_GetRingBufferReadAvailable(&m_ringbuffer);
-  if (available < frame_count) {
+  if (available < static_cast<ring_buffer_size_t>(frame_count)) {
     // Clear the undefined buffer content to zero
     frames_to_send = available;
     for (size_t i = available * m_nchannels; i < frame_count * m_nchannels;
@@ -299,7 +299,7 @@ bool PortAudioOutput::write(const SampleVector &samples) {
 
   ring_buffer_size_t avail_size =
       PaUtil_GetRingBufferWriteAvailable(&m_ringbuffer);
-  if (avail_size >= sample_size) {
+  if (avail_size >= static_cast<ring_buffer_size_t>(sample_size)) {
     PaUtil_WriteRingBuffer(&m_ringbuffer, m_floatbuf.data(), sample_size);
     return true;
   } else {

--- a/sfmbase/AudioOutput.cpp
+++ b/sfmbase/AudioOutput.cpp
@@ -33,6 +33,9 @@ extern "C" {
 #include "pa_ringbuffer.h"
 }
 
+// Uncomment this to set shorter default latency
+// #define PA_LOW_LATENCY 1
+
 // class SndfileOutput
 
 // Constructor
@@ -213,8 +216,13 @@ PortAudioOutput::PortAudioOutput(const PaDeviceIndex device_index,
 
   m_outputparams.channelCount = m_nchannels;
   m_outputparams.sampleFormat = paFloat32;
+#ifdef PA_LOW_LATENCY
   m_outputparams.suggestedLatency =
       Pa_GetDeviceInfo(m_outputparams.device)->defaultLowOutputLatency;
+#else  // !PA_LOW_LATENCY
+  m_outputparams.suggestedLatency =
+      Pa_GetDeviceInfo(m_outputparams.device)->defaultHighOutputLatency;
+#endif // PA_LOW_LATENCY
   m_outputparams.hostApiSpecificStreamInfo = NULL;
 
   fmt::println(stderr, "suggestedLatency = {:f}",

--- a/sfmbase/AudioOutput.cpp
+++ b/sfmbase/AudioOutput.cpp
@@ -293,7 +293,7 @@ int PortAudioOutput::stream_callback(float *output, unsigned long frame_count) {
   if (frames_to_send < sample_size) {
     // Ensure remaining output is zero
     // (Without doing this buzzing will occur!)
-    for (size_t i = frames_to_send; i < sample_size; i++) {
+    for (size_t i = frames_to_send; i < static_cast<size_t>(sample_size); i++) {
       output[i] = 0.0f;
     }
   }

--- a/sfmbase/AudioOutput.cpp
+++ b/sfmbase/AudioOutput.cpp
@@ -265,6 +265,22 @@ PortAudioOutput::~PortAudioOutput() {
   }
 }
 
+// Static C-style callback function for PortAudio stream.
+// user_data has the pointer to the PortAudio object itself ('this').
+int pa_callback(const void *input, void *output, unsigned long frame_count,
+                const PaStreamCallbackTimeInfo *time_info,
+                PaStreamCallbackFlags status_flags, void *user_data) {
+  PortAudioOutput *portaudio_object = static_cast<PortAudioOutput *>(user_data);
+  return portaudio_object->stream_callback(static_cast<float *>(output),
+                                           frame_count);
+}
+
+// Actual C++ callback code for PortAudio stream.
+int stream_callback(float *output, unsigned long frame_count) {
+  // TODO: Dummy code
+  return 0;
+}
+
 // Write audio data.
 bool PortAudioOutput::write(const SampleVector &samples) {
   if (m_zombie) {

--- a/sfmbase/AudioOutput.cpp
+++ b/sfmbase/AudioOutput.cpp
@@ -211,8 +211,8 @@ PortAudioOutput::PortAudioOutput(const PaDeviceIndex device_index,
 
   m_outputparams.channelCount = m_nchannels;
   m_outputparams.sampleFormat = paFloat32;
-  m_outputparams.suggestedLatency = 0.2;
-  // Pa_GetDeviceInfo(m_outputparams.device)->defaultLowOutputLatency;
+  m_outputparams.suggestedLatency =
+      Pa_GetDeviceInfo(m_outputparams.device)->defaultHighOutputLatency;
   m_outputparams.hostApiSpecificStreamInfo = NULL;
 
   // Guarantee minimum latency.

--- a/sfmbase/AudioOutput.cpp
+++ b/sfmbase/AudioOutput.cpp
@@ -256,9 +256,6 @@ PortAudioOutput::PortAudioOutput(const PaDeviceIndex device_index,
 
 // Output closing method.
 void PortAudioOutput::output_close() {
-  // Set closed flag to prevent multiple closing
-  m_closed = true;
-  m_zombie = true;
   m_paerror = Pa_StopStream(m_stream);
   if (m_paerror != paNoError) {
     add_paerror("Pa_StopStream()");
@@ -270,6 +267,8 @@ void PortAudioOutput::output_close() {
     return;
   }
   Pa_Terminate();
+  m_closed = true;
+  // Set closed flag to prevent multiple closing
 }
 
 // Destructor.

--- a/sfmbase/AudioOutput.cpp
+++ b/sfmbase/AudioOutput.cpp
@@ -26,10 +26,12 @@
 
 #include "AudioOutput.h"
 #include "SoftFM.h"
-#include "Utility.h"
-#include "pa_ringbuffer.h"
 #include "portaudio.h"
 #include "sndfile.h"
+
+extern "C" {
+#include "pa_ringbuffer.h"
+}
 
 // class SndfileOutput
 

--- a/sfmbase/AudioOutput.cpp
+++ b/sfmbase/AudioOutput.cpp
@@ -26,6 +26,7 @@
 
 #include "AudioOutput.h"
 #include "SoftFM.h"
+#include "portaudio.h"
 #include "sndfile.h"
 
 // class SndfileOutput
@@ -267,18 +268,25 @@ PortAudioOutput::~PortAudioOutput() {
 
 // Static C-style callback function for PortAudio stream.
 // user_data has the pointer to the PortAudio object itself ('this').
-int pa_callback(const void *input, void *output, unsigned long frame_count,
-                const PaStreamCallbackTimeInfo *time_info,
-                PaStreamCallbackFlags status_flags, void *user_data) {
+inline int pa_callback(const void *input, void *output,
+                       unsigned long frame_count,
+                       const PaStreamCallbackTimeInfo *time_info,
+                       PaStreamCallbackFlags status_flags, void *user_data) {
   PortAudioOutput *portaudio_object = static_cast<PortAudioOutput *>(user_data);
   return portaudio_object->stream_callback(static_cast<float *>(output),
                                            frame_count);
 }
 
 // Actual C++ callback code for PortAudio stream.
-int stream_callback(float *output, unsigned long frame_count) {
-  // TODO: Dummy code
-  return 0;
+inline int PortAudioOutput::stream_callback(float *output,
+                                            unsigned long frame_count) {
+  ring_buffer_size_t available_elements =
+      PaUtil_GetRingBufferReadAvailable(&m_ringbuffer);
+  ring_buffer_size_t read_size =
+      rbs_min(available_elements, ringbuffer_frame_size);
+  (void)PaUtil_ReadRingBuffer(&m_ringbuffer, output, read_size);
+  // TODO: return paComplete if playback ends
+  return paContinue;
 }
 
 // Write audio data.

--- a/sfmbase/AudioOutput.cpp
+++ b/sfmbase/AudioOutput.cpp
@@ -179,6 +179,11 @@ PortAudioOutput::PortAudioOutput(const PaDeviceIndex device_index,
                                  unsigned int samplerate, bool stereo) {
   m_nchannels = stereo ? 2 : 1;
 
+  // Initialize ring buffer
+  m_ringbuffer_data.resize(ringbuffer_length);
+  PaUtil_InitializeRingBuffer(&m_ringbuffer, sizeof(float), ringbuffer_length,
+                              m_ringbuffer_data.data());
+
   m_paerror = Pa_Initialize();
   if (m_paerror != paNoError) {
     add_paerror("Pa_Initialize()");


### PR DESCRIPTION
* Changed PortAudioOutput to use its own callback code instead of the stock blocking stream, for shorter output latency.
* PortAudio minimum latency is no longer explicitly set, and is now set to defaultHighOutputLatency. Note: this behavior can be changed by setting the compilation flag `PA_LOW_LATENCY` to defaultLowOutputLatency. Practically, in many cases, the low output latency setting works fine, but it is not the default value for safety reasons.
* Minimal `pa_ringbuffer` library code for handling the PortAudio callback was duplicated and included from PortAudio under the PortAudio V19 License. Note: the ringbuffer code is *not* a Git submodule.
* CMake minimum version is now 3.25.